### PR TITLE
fix(core): verify gossip source matches claimed peer_id in auction bids/receipts

### DIFF
--- a/node/crates/c0mpute-core/src/buyer.rs
+++ b/node/crates/c0mpute-core/src/buyer.rs
@@ -124,6 +124,14 @@ pub async fn run_auction(
                     if bid.job_id == job_id
                         && bid.bidder_peer_id != offer.buyer_peer_id
                     {
+                        if !source_matches_claim(&msg, &bid.bidder_peer_id) {
+                            warn!(
+                                %job_id,
+                                claimed = %bid.bidder_peer_id,
+                                "buyer: discarding bid, gossip source does not match claimed bidder_peer_id"
+                            );
+                            continue;
+                        }
                         debug!(
                             %job_id,
                             bidder = %bid.bidder_peer_id,
@@ -185,6 +193,14 @@ pub async fn run_auction(
                     if receipt.job_id == job_id
                         && receipt.worker_peer_id == winner.bidder_peer_id
                     {
+                        if !source_matches_claim(&msg, &receipt.worker_peer_id) {
+                            warn!(
+                                %job_id,
+                                claimed = %receipt.worker_peer_id,
+                                "buyer: discarding receipt, gossip source does not match claimed worker_peer_id"
+                            );
+                            continue;
+                        }
                         info!(
                             %job_id,
                             status = ?receipt.status,
@@ -233,6 +249,19 @@ async fn publish_json<T: serde::Serialize>(
         }
     }
     net.publish(topic, bytes).await
+}
+
+/// Gossipsub gives us a cryptographically-authenticated `source: Option<PeerId>`
+/// (see `c0mpute_net::GossipMessage`) that cannot be forged by another peer —
+/// `capabilities.rs`'s ad registry already keys off it for the same reason.
+/// `JobBid.bidder_peer_id` / `JobReceipt.worker_peer_id` are just self-reported
+/// strings inside the signed-later-but-not-yet payload, so without this check
+/// any peer can claim to be any other peer_id in a bid or completion receipt.
+fn source_matches_claim(msg: &GossipMessage, claimed_peer_id: &str) -> bool {
+    match &msg.source {
+        Some(source) => source.to_base58() == claimed_peer_id,
+        None => false,
+    }
 }
 
 fn unix_ms() -> u64 {


### PR DESCRIPTION
Fixes #9.

`run_auction()` matched incoming `JobBid`/`JobReceipt` gossip messages only on the self-reported `bidder_peer_id`/`worker_peer_id` field inside the JSON payload, never against `GossipMessage.source` — the libp2p-authenticated sender identity that's already attached to every message and can't be forged. `capabilities.rs`'s capability-ad registry already keys off `source` for exactly this reason; the auction path didn't follow the same pattern.

Since `JobAccept` (naming the winning bidder) is broadcast publicly, any peer can see who won a job and race to publish a bid or completion receipt claiming to be that peer — `run_auction()` returns on the first message matching job_id + the claimed string, forged or not.

## Change

Added `source_matches_claim()` and call it before accepting a bid (bid-collection loop) or a receipt (receipt-wait loop). Mismatches are discarded with a `warn!` log, same style as the existing discard-and-log pattern already used elsewhere in this file and in `capabilities.rs`.

This is independent of and doesn't replace the DID-signature scheme mentioned in `JobReceipt.signature`'s doc comment (that's presumably still coming from CoinPay) — it's a free, already-available authentication check that should hold regardless.

## Testing

I don't have a Rust toolchain in my environment to run `cargo test -p c0mpute-core` or `cargo check`, so I traced the types by hand instead of compiling:
- `GossipMessage.source: Option<PeerId>` (`c0mpute-net/src/swarm.rs`) — already imported via the existing `use c0mpute_net::{GossipMessage, Libp2pNetwork};`.
- `PeerId::to_base58()` — already used earlier in the same file (`net.peer_id().to_base58()`), so it's the right method.
- No new dependencies, no Cargo.toml changes.

Please run the test suite before merging since I couldn't verify it compiles locally — happy to fix anything that doesn't build.
