### PR TITLE
feat(cli): worker start -d|--daemon to detach as a background daemon

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -501,8 +501,10 @@ dependencies = [
  "c0mpute-secure-chat",
  "c0mpute-update",
  "clap",
+ "daemonize",
  "dialoguer",
  "hex",
+ "libc",
  "rpassword",
  "serde_json",
  "tokio",
@@ -1001,6 +1003,15 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn",
+]
+
+[[package]]
+name = "daemonize"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ab8bfdaacb3c887a54d41bdf48d3af8873b3f5566469f8ba21b92057509f116e"
+dependencies = [
+ "libc",
 ]
 
 [[package]]

--- a/README.md
+++ b/README.md
@@ -53,6 +53,31 @@ c0mpute coinpay reputation inspect did:coinpay:worker:abc123
 The plugin form mirrors the URL namespace: `c0mpute.com/transcode`,
 `c0mpute.com/coinpay`, `c0mpute.com/infernet`.
 
+### Run the worker in the background
+
+```sh
+# quick, self-managed daemon: detaches, writes ~/.local/share/c0mpute/worker.{pid,log}
+c0mpute worker start -d
+c0mpute worker status
+c0mpute worker stop
+```
+
+For a long-running node, prefer systemd (restart-on-crash, journald logs).
+A ready-to-use **user** unit ships at
+[`scripts/systemd/c0mpute-worker.service`](scripts/systemd/c0mpute-worker.service):
+
+```sh
+mkdir -p ~/.config/systemd/user
+cp scripts/systemd/c0mpute-worker.service ~/.config/systemd/user/
+systemctl --user daemon-reload
+systemctl --user enable --now c0mpute-worker
+loginctl enable-linger "$USER"        # survive logout / reboot
+journalctl --user -u c0mpute-worker -f
+```
+
+Under systemd the worker runs in the foreground (no `-d`) — systemd owns the
+lifecycle. See the unit header for GPU/role customization via `systemctl --user edit`.
+
 ## Architecture at a glance
 
 ```

--- a/node/crates/c0mpute-cli/Cargo.toml
+++ b/node/crates/c0mpute-cli/Cargo.toml
@@ -25,3 +25,7 @@ rpassword = { workspace = true }
 base64 = { workspace = true }
 hex = { workspace = true }
 dialoguer = "0.11"
+
+[target.'cfg(unix)'.dependencies]
+daemonize = "0.5"
+libc = "0.2"

--- a/node/crates/c0mpute-cli/src/main.rs
+++ b/node/crates/c0mpute-cli/src/main.rs
@@ -161,6 +161,10 @@ enum WorkerCmd {
         storage: Option<String>,
         #[arg(long)]
         gpu: bool,
+        /// Detach and run in the background as a daemon (writes a PID file and
+        /// redirects output to a log). Use `worker stop` / `worker status`.
+        #[arg(short = 'd', long)]
+        daemon: bool,
     },
     /// Stop a running worker.
     Stop,
@@ -270,10 +274,29 @@ enum KeyCmd {
     Rotate,
 }
 
-#[tokio::main]
-async fn main() -> Result<()> {
-    init_tracing()?;
+fn main() -> Result<()> {
     let cli = Cli::parse();
+
+    // Daemonize BEFORE the async runtime starts. Forking is unsafe once the
+    // multi-threaded Tokio runtime has spawned worker threads, so this must
+    // happen while the process is still single-threaded. Only `worker start
+    // --daemon` detaches; every other command runs in the foreground.
+    if let Some(Cmd::Worker {
+        cmd: WorkerCmd::Start { daemon: true, .. },
+    }) = &cli.command
+    {
+        daemonize_worker()?;
+    }
+
+    init_tracing()?;
+
+    let runtime = tokio::runtime::Builder::new_multi_thread()
+        .enable_all()
+        .build()?;
+    runtime.block_on(run_app(cli))
+}
+
+async fn run_app(cli: Cli) -> Result<()> {
     let config_path = cli.config.unwrap_or_else(config::default_config_path);
 
     // No subcommand: open the interactive menu in a terminal, else print help
@@ -392,18 +415,23 @@ async fn run_worker(cmd: WorkerCmd, config_path: &std::path::Path) -> Result<()>
             Ok(())
         }
         WorkerCmd::Status => {
+            match read_worker_pid() {
+                Some(pid) if pid_alive(pid) => println!("worker: running (pid {pid})"),
+                Some(pid) => println!("worker: not running (stale pid {pid})"),
+                None => println!("worker: not running"),
+            }
             let cfg = Config::load_or_default(config_path)?;
             println!("{}", serde_json::to_string_pretty(&cfg)?);
             Ok(())
         }
-        WorkerCmd::Stop => {
-            println!("[stub] no running worker to stop");
-            Ok(())
-        }
+        WorkerCmd::Stop => stop_worker(),
         WorkerCmd::Start {
             roles,
             storage: _,
             gpu,
+            // Already handled in `main` before the runtime started; at this
+            // point we are the (possibly detached) worker process.
+            daemon: _,
         } => {
             let mut cfg = Config::load_or_default(config_path)?;
             if let Some(rs) = roles {
@@ -416,6 +444,111 @@ async fn run_worker(cmd: WorkerCmd, config_path: &std::path::Path) -> Result<()>
             sup.run().await
         }
     }
+}
+
+// ────────────────────────────────────────────────────────────────────────
+// worker daemon: detach, PID file, stop/status
+// ────────────────────────────────────────────────────────────────────────
+
+/// `(pid_file, log_file)` for the background worker, under the data dir
+/// (`~/.local/share/c0mpute` on Linux), falling back to the cwd.
+fn worker_runtime_paths() -> (PathBuf, PathBuf) {
+    let dir = config::data_dir().unwrap_or_else(|| PathBuf::from("."));
+    (dir.join("worker.pid"), dir.join("worker.log"))
+}
+
+fn read_worker_pid() -> Option<i32> {
+    let (pid_file, _) = worker_runtime_paths();
+    std::fs::read_to_string(&pid_file)
+        .ok()
+        .and_then(|s| s.trim().parse::<i32>().ok())
+}
+
+/// Fork into the background, redirect stdout/stderr to the worker log, and
+/// write a locked PID file. Runs before the Tokio runtime starts, so the
+/// process is still single-threaded when it forks.
+#[cfg(unix)]
+fn daemonize_worker() -> Result<()> {
+    use std::fs::OpenOptions;
+
+    let (pid_file, log_file) = worker_runtime_paths();
+    if let Some(parent) = pid_file.parent() {
+        std::fs::create_dir_all(parent)?;
+    }
+    let stdout = OpenOptions::new().create(true).append(true).open(&log_file)?;
+    let stderr = stdout.try_clone()?;
+
+    // Print to the launching terminal *before* forking — once detached,
+    // stdout points at the log file.
+    println!("c0mpute worker starting in background");
+    println!("  pid file: {}", pid_file.display());
+    println!("  logs:     {}", log_file.display());
+    println!("  stop:     c0mpute worker stop");
+
+    let cwd = std::env::current_dir().unwrap_or_else(|_| PathBuf::from("/"));
+    daemonize::Daemonize::new()
+        .pid_file(&pid_file)
+        .working_directory(cwd)
+        .stdout(stdout)
+        .stderr(stderr)
+        .start()
+        .map_err(|e| {
+            anyhow::anyhow!(
+                "failed to start worker daemon: {e} \
+                 (already running? check `c0mpute worker status`)"
+            )
+        })?;
+    Ok(())
+}
+
+#[cfg(not(unix))]
+fn daemonize_worker() -> Result<()> {
+    anyhow::bail!("`worker start --daemon` is only supported on Unix platforms")
+}
+
+/// True if a process with this PID exists (signal 0 probes without delivering).
+#[cfg(unix)]
+fn pid_alive(pid: i32) -> bool {
+    unsafe { libc::kill(pid, 0) == 0 }
+}
+
+#[cfg(not(unix))]
+fn pid_alive(_pid: i32) -> bool {
+    false
+}
+
+#[cfg(unix)]
+fn stop_worker() -> Result<()> {
+    match read_worker_pid() {
+        Some(pid) if pid_alive(pid) => {
+            if unsafe { libc::kill(pid, libc::SIGTERM) } == 0 {
+                println!("sent SIGTERM to worker (pid {pid})");
+                Ok(())
+            } else {
+                Err(anyhow::anyhow!(
+                    "failed to signal worker pid {pid}: {}",
+                    std::io::Error::last_os_error()
+                ))
+            }
+        }
+        Some(pid) => {
+            // Stale PID file — the flock is released, so the next `start`
+            // will reclaim it. Clean it up so `status` reads true.
+            let (pid_file, _) = worker_runtime_paths();
+            let _ = std::fs::remove_file(pid_file);
+            println!("no running worker (cleared stale pid {pid})");
+            Ok(())
+        }
+        None => {
+            println!("no running worker");
+            Ok(())
+        }
+    }
+}
+
+#[cfg(not(unix))]
+fn stop_worker() -> Result<()> {
+    anyhow::bail!("`worker stop` is only supported on Unix platforms")
 }
 
 // ────────────────────────────────────────────────────────────────────────

--- a/scripts/systemd/c0mpute-worker.service
+++ b/scripts/systemd/c0mpute-worker.service
@@ -1,0 +1,50 @@
+# c0mpute worker — systemd *user* unit.
+#
+# Runs `c0mpute worker start` in the foreground under systemd (NOT `-d`):
+# systemd owns the process lifecycle, restarts it on crash, and captures
+# stdout/stderr into the journal. The built-in `--daemon` flag is for running
+# detached WITHOUT systemd — don't combine the two.
+#
+# Install (per-user, no root; matches the ~/.c0mpute/bin install layout):
+#
+#   mkdir -p ~/.config/systemd/user
+#   cp scripts/systemd/c0mpute-worker.service ~/.config/systemd/user/
+#   systemctl --user daemon-reload
+#   systemctl --user enable --now c0mpute-worker
+#   loginctl enable-linger "$USER"        # keep running after logout / across reboots
+#
+#   systemctl --user status c0mpute-worker
+#   journalctl --user -u c0mpute-worker -f
+#   systemctl --user restart c0mpute-worker
+#   systemctl --user disable --now c0mpute-worker
+#
+# Customize roles/GPU without editing this file (survives updates):
+#
+#   systemctl --user edit c0mpute-worker
+#   # then, in the drop-in:
+#   #   [Service]
+#   #   ExecStart=
+#   #   ExecStart=%h/.c0mpute/bin/c0mpute worker start --gpu --roles storage,gateway
+#
+# For a system-wide install instead, drop this in /etc/systemd/system/,
+# add `User=<user>`, and swap `%h` for that user's home (e.g. /home/<user>).
+
+[Unit]
+Description=c0mpute worker (p2p compute node)
+Documentation=https://c0mpute.com
+After=network-online.target
+Wants=network-online.target
+
+[Service]
+Type=simple
+# Foreground start — systemd manages the process, so no --daemon here.
+ExecStart=%h/.c0mpute/bin/c0mpute worker start
+Restart=on-failure
+RestartSec=5
+# Give in-flight jobs a moment to wind down on stop before SIGKILL.
+TimeoutStopSec=30
+# Peer CLIs (coinpay, infernet) also install under ~/.c0mpute/bin.
+Environment=PATH=%h/.c0mpute/bin:%h/.local/bin:/usr/local/bin:/usr/bin:/bin
+
+[Install]
+WantedBy=default.target


### PR DESCRIPTION
## What

Adds `c0mpute worker start -d|--daemon` to run the worker detached as a background daemon, and wires up the previously-stubbed `worker stop` / `worker status` commands.

## Why

`worker start` only ran in the foreground and blocked forever; `worker stop` was a stub (`[stub] no running worker to stop`) and `status` only dumped the config. There was no way to run the worker as a daemon short of `nohup`/systemd.

## How

- New `-d`/`--daemon` flag on `worker start`. When set, the process forks into the background, redirects stdout/stderr to `~/.local/share/c0mpute/worker.log`, and writes an flock'd PID file at `~/.local/share/c0mpute/worker.pid`.
- **Fork-before-runtime**: `main` is no longer `#[tokio::main]`. It parses args and daemonizes while still single-threaded (forking after the multi-threaded Tokio runtime spawns worker threads is unsafe), then builds the runtime manually and drives everything via `run_app()`.
- `worker stop` → reads the PID file and sends `SIGTERM`; clears stale PID files.
- `worker status` → reports `running (pid N)` / `not running` / `stale pid`, then the config.
- Unix-only bits are `#[cfg(unix)]` gated with clear errors on other platforms (adds `daemonize` + `libc` as `cfg(unix)` deps).

## Testing

Verified end-to-end on Linux:
- `worker start -d` returns immediately; process reparents to PID 1 (detached), PID + log files written.
- `worker status` → `running (pid N)`; supervisor tracing confirmed landing in `worker.log`.
- `worker stop` → SIGTERM, process terminates.
- Stale-PID path: a dead PID is reported as stale by `status` and cleared by `stop`.
- Both `cargo build` (debug) and `cargo build --release` pass clean.

## Note

After a live `stop`, `status` reports `stale pid` until the next `start`/`stop` — the `daemonize` crate holds the pidfile flock and doesn't unlink on exit. Left intentionally: the flock is what prevents a double-start race, so unlinking on stop would open a brief two-worker window.

🤖 Generated with [Claude Code](https://claude.com/claude-code)