### PR TITLE
docs(web): document WebMCP tools on the docs page

### DIFF
--- a/apps/web/src/app/docs/page.tsx
+++ b/apps/web/src/app/docs/page.tsx
@@ -3,7 +3,7 @@ import { CodeBlock as Code } from "@/components/CodeBlock";
 
 export const metadata = {
   title: "docs — c0mpute",
-  description: "CLI reference and cookbook for c0mpute: install, identity, workers, transcode jobs, AI inference, reputation, plugins, and health checks.",
+  description: "CLI reference and cookbook for c0mpute: install, identity, workers, transcode jobs, AI inference, reputation, plugins, WebMCP tools for AI agents, and health checks.",
   alternates: { canonical: "https://c0mpute.com/docs" },
 };
 
@@ -239,6 +239,42 @@ c0mpute plugin uninstall my-plugin`}
 {`c0mpute doctor                         # full report
 c0mpute doctor --fix                   # auto-apply known remediations
 c0mpute doctor --report                # send anonymized telemetry`}
+        </Code>
+      </Section>
+
+      <Section h="agents" title="[ ai agents / webmcp ]">
+        <P>
+          c0mpute.com speaks{" "}
+          <a href="https://webmachinelearning.github.io/webmcp/">WebMCP</a> — a
+          browser AI agent visiting the site can call its tools directly instead
+          of scraping the page. Tools register on{" "}
+          <code>document.modelContext</code> and are a no-op in browsers that
+          don&apos;t implement the (draft) spec.
+        </P>
+        <P>Tools exposed on every page:</P>
+        <ul className="space-y-1 pl-5 text-sm leading-6">
+          <li>
+            <code>c0mpute_list_plugins</code> — the plugin catalogue with install
+            commands (also at <Link href="/api/plugins">/api/plugins</Link>)
+          </li>
+          <li>
+            <code>c0mpute_network_status</code> — live workers, jobs in flight,
+            24h throughput, latency (also at <code>/api/status</code>)
+          </li>
+          <li>
+            <code>c0mpute_latest_release</code> — CLI release manifest &amp;
+            per-platform artifacts
+          </li>
+          <li>
+            <code>c0mpute_install_command</code> — install command for the CLI or
+            a plugin by id
+          </li>
+        </ul>
+        <P>Any WebMCP-capable client can enumerate them:</P>
+        <Code>
+{`// in a page context on c0mpute.com
+const tools = await document.modelContext.getTools();
+const status = await document.modelContext.callTool("c0mpute_network_status", {});`}
         </Code>
       </Section>
 


### PR DESCRIPTION
Follow-up to #14. That PR shipped the WebMCP tools but nothing on the site documented them.

Adds an **`[ ai agents / webmcp ]`** section to `/docs` that:
- explains c0mpute.com speaks [WebMCP](https://webmachinelearning.github.io/webmcp/) and degrades to a no-op where unsupported
- lists the four tools (`c0mpute_list_plugins`, `c0mpute_network_status`, `c0mpute_latest_release`, `c0mpute_install_command`) and their equivalent public endpoints
- shows a `document.modelContext` usage snippet

Also mentions WebMCP in the docs page metadata for discoverability.

Verified: `tsc --noEmit` clean; dev-server render of `/docs` shows the new section.

🤖 Generated with [Claude Code](https://claude.com/claude-code)