### PR TITLE
blog: serve last known good instead of 500 when SQLite Cloud blinks

### DIFF
--- a/apps/web/src/lib/blog-db.ts
+++ b/apps/web/src/lib/blog-db.ts
@@ -150,6 +150,99 @@ async function cacheDelListKeys(): Promise<void> {
 
 const CACHE_TTL = 30 * 60;
 
+// How long a last-known-good copy is kept to serve when SQLite Cloud is
+// unreachable. Long, because its only job is to cover an outage: a week-old
+// post list is a far better answer than a 500.
+const STALE_TTL = 7 * 24 * 60 * 60;
+
+// Deliberately NOT under `blog:list:` — cacheDelListKeys() wipes that prefix on
+// every publish, which would throw the safety net away at the exact moment the
+// site is being written to.
+function staleKey(key: string): string {
+  return `blog:stale:${key}`;
+}
+
+async function staleSet(key: string, value: unknown): Promise<void> {
+  try {
+    const redis = getRedis();
+    if (!redis) return;
+    await redis.set(staleKey(key), JSON.stringify(value), "EX", STALE_TTL);
+  } catch {}
+}
+
+async function staleGet<T>(key: string): Promise<T | null> {
+  try {
+    const redis = getRedis();
+    if (!redis) return null;
+    const raw = await redis.get(staleKey(key));
+    return raw ? (JSON.parse(raw) as T) : null;
+  } catch {
+    return null;
+  }
+}
+
+// Last-known-good, in this process.
+//
+// REDIS_URL is referenced exactly once in this repository — by getRedis(), a
+// few lines above — and is set nowhere: no .env.example, no deploy config, no
+// documentation. So every Redis path here is a no-op in production, and a
+// last-known-good copy that lives only in Redis would never once be read.
+//
+// `next start` is a long-running server, so a plain Map outlives any number of
+// requests and covers exactly the failure this is for: a database that works,
+// then briefly does not, then works again.
+//
+// Used ONLY on the failure path, never as the happy-path cache. Publishing
+// invalidates through cacheDelListKeys(), which can only reach Redis; an
+// in-process *fresh* cache would therefore hide new posts for a full TTL.
+const lastGood = new Map<string, unknown>();
+
+// Enough for every (limit, offset) a page or feed asks for, bounded so a
+// hostile or buggy caller cannot grow it without end.
+const LAST_GOOD_MAX = 64;
+
+function rememberGood(key: string, value: unknown): void {
+  if (!lastGood.has(key) && lastGood.size >= LAST_GOOD_MAX) {
+    const oldest = lastGood.keys().next().value;
+    if (oldest !== undefined) lastGood.delete(oldest);
+  }
+  lastGood.set(key, value);
+}
+
+/**
+ * Read through the cache, falling back to the last-known-good copy.
+ *
+ * The blog is served from SQLite Cloud, which intermittently refuses a
+ * connection — c0mpute.com/blog and its feed were observed returning 500 and
+ * 200 minutes apart with no deploy in between. withReconnect() already retries
+ * once, but when the retry fails too the error reaches the route and Next
+ * answers 500, and a feed that 500s is one every reader eventually treats as
+ * dead. So an outage degrades to slightly stale content rather than to none.
+ *
+ * If nothing has ever succeeded in this process, the error is rethrown: an
+ * empty feed served as 200 would claim the blog has no posts, which is worse
+ * than an honest failure.
+ */
+async function readCached<T>(cacheKey: string, load: () => Promise<T>): Promise<T> {
+  const cached = await cacheGet<T>(cacheKey);
+  if (cached) return cached;
+
+  try {
+    const fresh = await load();
+    await cacheSet(cacheKey, fresh);
+    await staleSet(cacheKey, fresh);
+    rememberGood(cacheKey, fresh);
+    return fresh;
+  } catch (e) {
+    const stale = (lastGood.get(cacheKey) as T | undefined) ?? (await staleGet<T>(cacheKey));
+    if (stale) {
+      console.error(`blog-db: ${cacheKey} failed, serving last known good —`, e);
+      return stale;
+    }
+    throw e;
+  }
+}
+
 // ── Public types & helpers ────────────────────────────────────────────────────
 
 export interface BlogPost {
@@ -200,23 +293,18 @@ export async function upsertPost(post: NewPost): Promise<void> {
 }
 
 export async function listPosts(limit = 50, offset = 0): Promise<BlogPost[]> {
-  const cacheKey = `blog:list:${limit}:${offset}`;
-  const cached = await cacheGet<BlogPost[]>(cacheKey);
-  if (cached) return cached;
-
-  const posts = await withReconnect(async () => {
-    const db = await getDb();
-    const rows = await db
-      .select()
-      .from(blogPosts)
-      .orderBy(desc(blogPosts.published_at))
-      .limit(limit)
-      .offset(offset);
-    return rows.map(hydrate);
-  });
-
-  await cacheSet(cacheKey, posts);
-  return posts;
+  return readCached(`blog:list:${limit}:${offset}`, () =>
+    withReconnect(async () => {
+      const db = await getDb();
+      const rows = await db
+        .select()
+        .from(blogPosts)
+        .orderBy(desc(blogPosts.published_at))
+        .limit(limit)
+        .offset(offset);
+      return rows.map(hydrate);
+    }),
+  );
 }
 
 export async function getPost(slug: string): Promise<BlogPost | null> {


### PR DESCRIPTION
## The symptom

`c0mpute.com/blog` and `/blog/rss.xml` intermittently answer **500**. Observed today with no deploy in between:

| Probe | `/blog` | `/blog/rss.xml` |
|---|---|---|
| first | 500 | 200 (27 items) |
| minutes later | 200 | 500 |
| 6× in a row after that | — | 200 ×6 |

So it is transient, and either route can be the one that fails.

`listPosts()` already retries once via `withReconnect()`, but when the retry fails too the error reaches the route and Next answers a bare 500.

## Why it matters more for the feed

A blog page that fails is a page someone reloads. A feed that 500s is one every reader eventually stops polling and treats as dead — and this feed is listed in `profullstack.com/feeds.opml` and in the smallweb list, so the failure is visible to subscribers rather than just to visitors.

## The change

Reads go through `readCached()`, which keeps a last-known-good copy and serves it when the database cannot be reached. An outage degrades to slightly stale posts instead of no posts.

When nothing has ever succeeded, the error is still thrown — an empty feed served as 200 would claim the blog has no posts, which is worse than an honest failure.

Two details that are load-bearing:

- **The copy is kept in process, not only in Redis.** `REDIS_URL` is referenced exactly once in this repository — by `getRedis()` — and is set nowhere: no `.env.example`, no deploy config, no docs. Every Redis path here is already a no-op in production, so a fallback that lived only in Redis would never once be read. `next start` is long-running, so a `Map` covers exactly this failure. The Redis copy is written too, for when it is configured.
- **The Redis copy is under `blog:stale:`, not `blog:list:`.** `cacheDelListKeys()` wipes `blog:list:*` on every publish, which would throw the safety net away at the precise moment the site is being written to.

The in-process copy is used **only** on the failure path, never as the happy-path cache: publishing invalidates through Redis, so an in-process *fresh* cache would hide new posts for a full TTL.

`getPost()` is left alone — it deliberately does not cache misses, and a single post page failing does not make a feed look dead.

## Root cause, not fixed here

This is SQLite Cloud refusing connections. c0upons hit the same provider's limits and migrated to Turso. This PR makes the blog survive the blips; it does not change the database. Worth deciding separately whether c0mpute follows c0upons off SQLite Cloud.

## Verification

- `tsc --noEmit` clean.
- `next build` succeeds; `/blog`, `/blog/[slug]` and `/blog/rss.xml` are still dynamic.
- No test suite exists in this repo (CI runs codeql/security/threatcrush only), so no tests were added — flagging rather than inventing a harness in a drive-by fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)