### PR TITLE
release: v0.2.26 — blog feed survives a database blip

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -476,7 +476,7 @@ checksum = "1e748733b7cbc798e1434b6ac524f0c1ff2ab456fe201501e6497c8417a4fc33"
 
 [[package]]
 name = "c0mpute-api"
-version = "0.2.25"
+version = "0.2.26"
 dependencies = [
  "anyhow",
  "c0mpute-proto",
@@ -491,7 +491,7 @@ dependencies = [
 
 [[package]]
 name = "c0mpute-cli"
-version = "0.2.25"
+version = "0.2.26"
 dependencies = [
  "anyhow",
  "base64",
@@ -514,7 +514,7 @@ dependencies = [
 
 [[package]]
 name = "c0mpute-core"
-version = "0.2.25"
+version = "0.2.26"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -547,7 +547,7 @@ dependencies = [
 
 [[package]]
 name = "c0mpute-doctor"
-version = "0.2.25"
+version = "0.2.26"
 dependencies = [
  "anyhow",
  "serde",
@@ -559,7 +559,7 @@ dependencies = [
 
 [[package]]
 name = "c0mpute-gateway"
-version = "0.2.25"
+version = "0.2.26"
 dependencies = [
  "anyhow",
  "axum",
@@ -577,7 +577,7 @@ dependencies = [
 
 [[package]]
 name = "c0mpute-net"
-version = "0.2.25"
+version = "0.2.26"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -594,7 +594,7 @@ dependencies = [
 
 [[package]]
 name = "c0mpute-proto"
-version = "0.2.25"
+version = "0.2.26"
 dependencies = [
  "blake3",
  "hex",
@@ -606,7 +606,7 @@ dependencies = [
 
 [[package]]
 name = "c0mpute-secure-chat"
-version = "0.2.25"
+version = "0.2.26"
 dependencies = [
  "aes-gcm",
  "anyhow",
@@ -629,7 +629,7 @@ dependencies = [
 
 [[package]]
 name = "c0mpute-store"
-version = "0.2.25"
+version = "0.2.26"
 dependencies = [
  "anyhow",
  "blake3",
@@ -644,7 +644,7 @@ dependencies = [
 
 [[package]]
 name = "c0mpute-transcode"
-version = "0.2.25"
+version = "0.2.26"
 dependencies = [
  "anyhow",
  "c0mpute-proto",
@@ -656,7 +656,7 @@ dependencies = [
 
 [[package]]
 name = "c0mpute-update"
-version = "0.2.25"
+version = "0.2.26"
 dependencies = [
  "anyhow",
  "hex",
@@ -670,7 +670,7 @@ dependencies = [
 
 [[package]]
 name = "c0mpute-verify"
-version = "0.2.25"
+version = "0.2.26"
 dependencies = [
  "anyhow",
  "blake3",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,7 +19,7 @@ members = [
 ]
 
 [workspace.package]
-version = "0.2.25"
+version = "0.2.26"
 edition = "2024"
 license = "MIT"
 repository = "https://github.com/profullstack/c0mpute"

--- a/apps/tui/package.json
+++ b/apps/tui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@c0mpute/tui",
-  "version": "0.2.25",
+  "version": "0.2.26",
   "private": true,
   "type": "module",
   "bin": {

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -1,6 +1,6 @@
 {
   "name": "c0mpute",
-  "version": "0.2.25",
+  "version": "0.2.26",
   "private": true,
   "type": "module",
   "scripts": {

--- a/apps/web/src/app/releases/latest.json/route.ts
+++ b/apps/web/src/app/releases/latest.json/route.ts
@@ -28,7 +28,7 @@ export const dynamic = "force-dynamic";
  * this in sync with the workspace version in `Cargo.toml` on each release so a
  * freshly built CLI reports "already latest" rather than a phantom upgrade.
  */
-const FALLBACK_VERSION = "0.2.25";
+const FALLBACK_VERSION = "0.2.26";
 const FALLBACK_MIN_REQUIRED = "0.0.1";
 
 type Channel = "stable" | "beta" | "nightly";

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "c0mpute-monorepo",
-  "version": "0.2.25",
+  "version": "0.2.26",
   "private": true,
   "workspaces": [
     "apps/*",


### PR DESCRIPTION
Bumps 0.2.25 → 0.2.26 across the six files the previous release touched: `Cargo.toml`, `Cargo.lock` (12 workspace crates), `package.json`, `apps/web/package.json`, `apps/tui/package.json`, and `FALLBACK_VERSION` in `apps/web/src/app/releases/latest.json/route.ts`.

**Worth being explicit:** no Rust changed since v0.2.25. All five commits in the range are web, CI or docs, so `release.yml` will build binaries byte-identical to the previous tag. This version marks the site, not the client.

Tagging `v0.2.26` at the merge commit is what fires `release.yml`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)