### PR TITLE
ci: add the Rust build + test gate

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -1,0 +1,119 @@
+name: rust
+
+# The Rust build/test gate.
+#
+# Until this existed, CI ran only security scanners (CodeQL, ThreatCrush,
+# gitleaks, semgrep, Socket, bun audit) — nothing compiled the workspace or ran
+# a test. A PR could break every crate in the tree and still show all-green.
+#
+# `build-and-test` is the gate and must stay blocking. `lint` is advisory for
+# now: the tree does not currently satisfy `cargo fmt --check`, and clippy has
+# pre-existing warnings in c0mpute-net and c0mpute-update. Making either
+# blocking today would redden every PR for reasons unrelated to its diff. Once
+# the tree is clean, drop the `continue-on-error` lines and they become real
+# gates — that is the point of running them now rather than waiting.
+
+on:
+  pull_request:
+  push:
+    branches: [master, main]
+
+# A new push supersedes an in-flight run for the same ref. Rust builds are the
+# most expensive job in this repo; there is no value in finishing one for a
+# commit that has already been replaced.
+concurrency:
+  group: rust-${{ github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+
+env:
+  CARGO_TERM_COLOR: always
+  # Fail on warnings only where we opt in below; see the lint job.
+  RUST_BACKTRACE: 1
+
+jobs:
+  build-and-test:
+    name: build + test
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+
+    steps:
+      - uses: actions/checkout@v5
+
+      # The toolchain version is read out of .mise.toml rather than pinned
+      # here, so CI cannot silently drift from what contributors run locally
+      # (DIP-0004 pins the contributor toolchain via mise). If the two were
+      # written in two places, they would disagree eventually and CI would be
+      # testing a compiler nobody uses.
+      - name: Resolve the pinned toolchain
+        id: toolchain
+        run: |
+          version=$(grep -E '^rust\s*=' .mise.toml | head -1 | sed -E 's/.*"([^"]+)".*/\1/')
+          if [ -z "$version" ]; then
+            echo "::error::could not read the rust version from .mise.toml"
+            exit 1
+          fi
+          echo "version=$version" >> "$GITHUB_OUTPUT"
+          echo "Using Rust $version (from .mise.toml)"
+
+      - uses: dtolnay/rust-toolchain@master
+        with:
+          toolchain: ${{ steps.toolchain.outputs.version }}
+
+      - uses: Swatinem/rust-cache@v2
+
+      # Build before testing so a compile error is reported as a compile
+      # error, rather than as an opaque failure inside `cargo test`.
+      - name: Build
+        run: cargo build --workspace --all-targets --locked
+
+      - name: Test
+        run: cargo test --workspace --locked
+
+  lint:
+    name: fmt + clippy (advisory)
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    # Advisory until the tree is clean — see the header comment. The result is
+    # still visible on every PR, so the backlog cannot quietly grow.
+    continue-on-error: true
+
+    steps:
+      - uses: actions/checkout@v5
+
+      - name: Resolve the pinned toolchain
+        id: toolchain
+        run: |
+          version=$(grep -E '^rust\s*=' .mise.toml | head -1 | sed -E 's/.*"([^"]+)".*/\1/')
+          echo "version=${version:-stable}" >> "$GITHUB_OUTPUT"
+
+      - uses: dtolnay/rust-toolchain@master
+        with:
+          toolchain: ${{ steps.toolchain.outputs.version }}
+          components: rustfmt, clippy
+
+      - uses: Swatinem/rust-cache@v2
+
+      - name: cargo fmt --check
+        continue-on-error: true
+        run: cargo fmt --all -- --check
+
+      - name: cargo clippy
+        continue-on-error: true
+        run: cargo clippy --workspace --all-targets
+
+      # Report what the two steps found in one place, so the advisory result is
+      # legible without opening the log.
+      - name: Summarise
+        if: always()
+        run: |
+          {
+            echo "## Rust lint (advisory)"
+            echo
+            echo "Not blocking yet: the tree has pre-existing \`cargo fmt\` diffs and"
+            echo "clippy warnings in \`c0mpute-net\` and \`c0mpute-update\`. Clear those and"
+            echo "remove the \`continue-on-error\` lines in \`.github/workflows/rust.yml\`"
+            echo "to turn this into a real gate."
+          } >> "$GITHUB_STEP_SUMMARY"


### PR DESCRIPTION
Adds the missing Rust build/test gate.

CI currently runs **only security scanners** — CodeQL, ThreatCrush, gitleaks, semgrep, Socket, bun audit. Nothing compiles the workspace or runs a test, so a PR could break every crate in the tree and still show all-green. Both bugs found while implementing CIP-002 (#21) would have sailed through.

## What's blocking vs. advisory

**`build-and-test` is the gate:**

```
cargo build --workspace --all-targets --locked
cargo test  --workspace --locked
```

**`lint` (fmt + clippy) is advisory**, deliberately. The tree does not currently satisfy `cargo fmt --check`, and clippy has pre-existing warnings in `c0mpute-net` and `c0mpute-update`. Making either blocking today reddens every PR for reasons unrelated to its diff. Running them now keeps the backlog visible rather than letting it grow silently — clear the tree, delete the `continue-on-error` lines, and they become real gates. The job summary says exactly that, so whoever hits it knows what to do.

## Notes

- The toolchain version is **read out of `.mise.toml`** rather than pinned in the workflow, so CI can't drift from what contributors run locally (DIP-0004). Written in two places, the two would disagree eventually and CI would be testing a compiler nobody uses.
- `--locked` so a PR that forgets to commit `Cargo.lock` fails loudly instead of silently resolving different dependencies than everyone else.
- `concurrency` with `cancel-in-progress` — Rust builds are the most expensive job here and there's no value finishing one for a superseded commit.
- No path filters: if this is ever made a required check, a filtered job that never runs would block PRs forever. `Swatinem/rust-cache` keeps it cheap instead.
- No extra system deps needed — the transcode tests don't shell out to `ffmpeg` (verified: the suite passes on a machine without it).

Worth merging ahead of #20/#21 so it gates them.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LsQAuvXkmyHTgnvquLHrRx
