### PR TITLE
Blog pages carry a CrawlProof unit by default

### DIFF
--- a/apps/web/src/app/blog/layout.tsx
+++ b/apps/web/src/app/blog/layout.tsx
@@ -1,0 +1,17 @@
+import Script from "next/script";
+
+/**
+ * Every blog page carries one CrawlProof unit under the post: the text strip,
+ * filled by ad.js, which collapses to nothing when there is no advertiser.
+ * The tracker is in the root layout; this is the ads half of the blog's
+ * defaults (tracking + ads, both on).
+ */
+export default function BlogLayout({ children }: { children: React.ReactNode }) {
+  return (
+    <>
+      {children}
+      <aside data-cp-ad="" data-slot="f68457c4-7402-4773-ab8f-8c802238d85a" data-format="text_link" />
+      <Script src="https://crawlproof.com/ad.js" strategy="afterInteractive" />
+    </>
+  );
+}


### PR DESCRIPTION
Every blog we run carries CrawlProof tracking and one ad unit by default. This site had the tracker; this adds a nested `blog/layout.tsx` that appends the text-strip unit for the site's own slot under every post (loading `ad.js` where the root layout did not). The strip collapses to 0px when no advertiser fills it.

Part of the fleet sweep alongside nichedb.dev, hqtui, c0mpute, pairux, c0upons, d0rz and bittorrented.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01YafYxayh7Gqe5MWNNQMev2