### PR TITLE
feat(protocol): signed envelopes, native DIDs, and the v2 message types

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -72,6 +72,18 @@ jobs:
       - name: Test
         run: cargo test --workspace --locked
 
+      # Blocking, unlike the lint job: this invariant has no legacy debt to
+      # work through, and it is cheap to keep green from the start.
+      #
+      # It re-canonicalizes every envelope shown in docs/protocol/ using
+      # Python's json.dumps(sort_keys=True) and compares byte-for-byte against
+      # what c0mpute-envelope produced. That catches a spec page going stale,
+      # and — the reason it is worth a CI slot — it checks that the canonical
+      # form is reproducible by a second implementation in another language,
+      # which is what every hash and signature on the network depends on.
+      - name: Protocol docs match the implementation
+        run: python3 scripts/check-protocol-docs.py
+
   lint:
     name: fmt + clippy (advisory)
     runs-on: ubuntu-latest

--- a/.gitleaksignore
+++ b/.gitleaksignore
@@ -1,0 +1,16 @@
+# Findings gitleaks reports that are not secrets.
+#
+# Add an entry only for something that is genuinely public. If you are not
+# certain, treat it as a leak: rotate first, argue afterwards.
+#
+# Format is a gitleaks fingerprint, `<commit>:<path>:<rule>:<line>`, taken
+# verbatim from the scan output. Fingerprints pin a commit, so history stays
+# covered without rewriting it.
+
+# The example ed25519 identifier from the did:key specification, used in a
+# test asserting that c0mpute rejects foreign DID methods. It is a *public*
+# key — a DID is a public key by construction — but it is 44 characters of
+# base58, and the generic-api-key rule scores on entropy alone. The line
+# also carries an inline `gitleaks:allow`, which covers future scans of the
+# working tree; this entry covers the commit that introduced it.
+8680fe8bfc104e376b89e780f73bda2075178ab2:node/crates/c0mpute-envelope/src/identity.rs:generic-api-key:276

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -564,6 +564,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "c0mpute-envelope"
+version = "0.2.26"
+dependencies = [
+ "blake3",
+ "bs58",
+ "ed25519-dalek",
+ "hex",
+ "serde",
+ "serde_json",
+ "thiserror 2.0.18",
+]
+
+[[package]]
 name = "c0mpute-gateway"
 version = "0.2.26"
 dependencies = [

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,6 +14,7 @@ members = [
     "node/crates/c0mpute-update",
     "node/crates/c0mpute-doctor",
     "node/crates/c0mpute-proto",
+    "node/crates/c0mpute-envelope",  # canonical serialization + signed protocol envelopes (DIP-0024)
     "node/crates/c0mpute-api",
     "node/crates/c0mpute-transcode",    # in-process transcode workload (FFmpeg)
     "node/crates/c0mpute-secure-chat",  # in-process E2E encrypted p2p messaging (DIP-0018)
@@ -62,9 +63,11 @@ sha2 = "0.10"
 rand = "0.8"
 zeroize = { version = "1", features = ["derive"] }
 base64 = "0.22"
+bs58 = "0.5"
 rpassword = "7"
 
 c0mpute-proto = { path = "node/crates/c0mpute-proto" }
+c0mpute-envelope = { path = "node/crates/c0mpute-envelope" }
 c0mpute-store = { path = "node/crates/c0mpute-store" }
 c0mpute-placement = { path = "node/crates/c0mpute-placement" }
 c0mpute-net = { path = "node/crates/c0mpute-net" }

--- a/README.md
+++ b/README.md
@@ -136,7 +136,8 @@ lifecycle. See the unit header for GPU/role customization via `systemctl --user 
 ```
 .
 ├── docs/
-│   ├── c0mpute-v1.md                  # v1 PRD (source of truth)
+│   ├── protocol/                      # the wire protocol — what interop requires
+│   ├── c0mpute-v1.md                  # v1 PRD (superseded where it conflicts with v2)
 │   └── prds/                          # CIPs — per-phase PRDs (see prds/README.md)
 ├── dips/                              # design proposals (the "why")
 ├── node/
@@ -145,6 +146,7 @@ lifecycle. See the unit header for GPU/role customization via `systemctl --user 
 │       ├── c0mpute-core/, c0mpute-net/, c0mpute-store/, c0mpute-gateway/
 │       ├── c0mpute-verify/, c0mpute-update/, c0mpute-doctor/
 │       ├── c0mpute-proto/, c0mpute-api/
+│       ├── c0mpute-envelope/            # canonical JSON, DIDs, signed envelopes
 │       └── c0mpute-transcode/           # in-process FFmpeg workload
 ├── plugins/                           # marketplace manifests only
 │   ├── transcode/module.toml          # in-process; code at node/crates/c0mpute-transcode
@@ -163,11 +165,27 @@ lifecycle. See the unit header for GPU/role customization via `systemctl --user 
 ```
 
 There is **no central backend** — no Supabase, no coordinator daemon.
-Discovery, dispatch, and verification flow through libp2p Kad-DHT +
-gossipsub. Identity, payments, escrow, and reputation flow through
-CoinPay DID. The only public infrastructure we host is static
-(landing site, release tarballs, bootstrap seed list, plugin manifest
-mirrors). See [DIP-0011](dips/0011-no-central-backend.md).
+Discovery and dispatch flow through libp2p Kad-DHT + gossipsub. The only
+public infrastructure we host is static (landing site, release tarballs,
+bootstrap seed list, plugin manifest mirrors). See
+[DIP-0011](dips/0011-no-central-backend.md).
+
+Every protocol record — provider adverts, job manifests, offers, receipts —
+carries **its own signature**, so it stays verifiable after it leaves the
+wire: relayed by an indexer, read back off disk, or shown to a third party
+who was never a peer. Identity is a locally generated `did:c0mpute:z…`
+needing no account and no payment product; CoinPay remains the default
+settlement adapter and the first-party integration, named on the wire
+rather than assumed. Indexers and gateways may cache, proxy and bill —
+none may be authoritative.
+
+> **If c0mpute.com disappears, c0mpute keeps computing.**
+
+See [`docs/protocol/`](docs/protocol/README.md) for the specification,
+[DIP-0024](dips/v2.x/0024-protocol-vs-hosted-services.md) for the rule that
+keeps hosted services optional, and
+[DIP-0025](dips/v2.x/0025-signed-envelopes-and-native-identity.md) for
+identity and envelopes.
 
 `plugins/` directory is for **marketplace metadata only**. Each plugin's
 `module.toml` describes how `c0mpute` discovers, dispatches to, and (in

--- a/dips/0007-coinpay-did-identity.md
+++ b/dips/0007-coinpay-did-identity.md
@@ -12,6 +12,14 @@ supersedes: 0003
 superseded-by:
 ---
 
+> **Amended by DIP-0025 (Draft).** The *identity* half of this DIP no longer
+> holds: network identity is now a natively generated `did:c0mpute:z…`, so a
+> peer can be discovered and verified with no payment product in the path. The
+> *payment, escrow, settlement and reputation* half stands — CoinPay is the
+> default settlement adapter and the first-party integration. What changed is
+> that it is no longer load-bearing for the network to run. See
+> `docs/protocol/identity.md`.
+
 ## Summary
 
 Every actor on the c0mpute network — buyer, worker, validator, organization

--- a/dips/README.md
+++ b/dips/README.md
@@ -118,9 +118,17 @@ superseded-by: <DIP-NNNN if this gets replaced>
 | 0014 | Public /status page + status-aggregator service                  | Accepted   |
 | 0015 | Hosting vertical: censorship-resistant static sites              | Draft      |
 | 0017 | Streaming reads: progressive RS reconstruction for sequential workloads | Draft |
+| 0018 | secure-chat — end-to-end encrypted p2p messaging plugin           | Draft      |
+| 0019 | live-stream — p2p HLS via BitTorrent-style segment swarming       | Draft      |
+| 0020 | ctv-ads — decentralized Connected TV ad marketplace               | Draft      |
+| 0021 | ads-manager — shared ad operations layer for the ad plugins       | Draft      |
+| 0022 | podcasting + podcasts — p2p podcast publishing and listening      | Draft      |
+| 0023 | podcast-ads — dynamic ad insertion for p2p podcasts               | Draft      |
 
 ### v2.x (`dips/v2.x/`)
 
 | #    | Title                                                            | Status     |
 |------|------------------------------------------------------------------|------------|
 | 0016 | Abuse policy: CSAM hash blocklist, per-worker opt-in             | Draft      |
+| 0024 | Separate the protocol from every hosted service that accelerates it | Draft   |
+| 0025 | Signed envelopes and native `did:c0mpute` identity                | Draft      |

--- a/dips/v2.x/0024-protocol-vs-hosted-services.md
+++ b/dips/v2.x/0024-protocol-vs-hosted-services.md
@@ -1,0 +1,169 @@
+---
+dip: 0024
+title: "Separate the protocol from every hosted service that accelerates it"
+status: Draft
+authors:
+  - anthony@profullstack.com
+created: 2026-09-07
+updated: 2026-09-07
+discussion:
+implementation: node/crates/c0mpute-envelope (DIP-0025); `--gateway none` CI gate pending Phase 2
+supersedes:
+superseded-by:
+---
+
+## Summary
+
+Every c0mpute component is exactly one of four things, and which one it is
+must be written down where the component lives:
+
+```text
+protocol requirement       an implementation MUST do this to interoperate
+reference implementation   how *we* do it; another node may differ
+optional hosted service    an accelerator; the network works without it
+first-party integration    our product, best-supported, never mandatory
+```
+
+Optional hosted services — indexers, gateways, dashboards, relays, fiat
+billing, the Infernet control plane — may cache, observe, proxy, bill for,
+and speed up the network. None of them may be **authoritative**: required
+in order for two honest peers to discover each other, agree on a price,
+execute work, verify a result, or produce a receipt.
+
+The rule this DIP exists to protect:
+
+> If c0mpute.com disappears, c0mpute keeps computing.
+
+## Motivation
+
+DIP-0011 already says c0mpute has no central application backend, and for
+c0mpute proper that has held: there is no Postgres, no Supabase, no
+coordinator daemon. But "no central backend" was asserted as a deletion,
+not as a property anything checks, and two things have drifted since.
+
+**Infernet still has an authoritative control plane.** Provider census,
+routing, heartbeats, job state, and distributed-inference coordination run
+through a hosted service. It works, and it is the reason Infernet shipped;
+it is also a single point at which the network can be switched off, and
+today nothing in the repository would fail if that dependency deepened.
+
+**The v1 market types rely on transport authenticity.** `CapabilityAd`,
+`JobOffer`, `JobBid`, `JobAccept` and `JobReceipt` in
+`c0mpute-net::topics` carry no signatures of their own — gossipsub signs
+each message with the publisher's key, and that is the whole of their
+provenance. A gossipsub signature dies at the first hop, so an advert
+relayed by an indexer or a receipt read back from disk is unverifiable.
+Reputation built on unverifiable receipts has to be believed on some
+operator's word, which means it has to live in some operator's database.
+The decentralization is real at the transport layer and absent at the
+record layer.
+
+Neither is a hosted service being *bad*. Managed gateways, indexers and
+fiat billing are genuinely useful, and a commercial layer is the plan
+(v2 direction §20). The problem is that "useful" and "load-bearing" look
+identical in a codebase until something breaks, and by then the dependency
+is everywhere.
+
+## Detailed design
+
+### The classification is written down
+
+Every architectural document, crate, and service README states which of
+the four categories it is in. Not a header for its own sake: it is the
+question you have to answer before adding a dependency, and writing it
+down is what makes the answer reviewable.
+
+### Core protocol crates may not depend on hosted-service SDKs
+
+Enforced in CI, not by convention:
+
+```text
+core protocol crates MUST NOT depend on:
+  Supabase SDKs
+  Railway-specific APIs
+  c0mpute.com hosted endpoints
+  managed billing implementations
+```
+
+The current core set is `c0mpute-envelope`, `c0mpute-proto`,
+`c0mpute-net`. `c0mpute-envelope` is already built to the rule: no libp2p,
+no HTTP client, no settlement implementation. Identity enters as raw
+ed25519 bytes; settlement is named by an open string rather than a closed
+enum, so CoinPay is the default rather than a requirement.
+
+A dependency check is cheap to write and catches the drift on the commit
+that introduces it, rather than at the release where someone finally asks
+whether the CLI works offline.
+
+### Hosted services are clients of the public protocol
+
+A managed gateway submits jobs, collects offers and reads receipts through
+the same messages any node uses. There is no privileged internal
+scheduling API, and no message type that only our infrastructure can
+produce. If a gateway needs a capability the protocol lacks, the fix is a
+protocol change everyone gets, not a private endpoint.
+
+This costs us something real — a private API would be faster to build —
+and it buys the property that a third-party gateway is as capable as ours,
+which is the difference between a protocol and a product with an SDK.
+
+### `--gateway none` is the release gate
+
+The claim "you do not need us" is only true if it is tested. Phase 2 adds
+`--gateway none` as a release-gating integration test: a job discovered,
+offered on, awarded, executed, validated and receipted with c0mpute.com,
+its APIs, its databases and the Infernet control plane all unreachable.
+
+Until that test exists and passes, this DIP is Draft and the website
+should not claim the property.
+
+### Indexers are a view, never a source
+
+An indexer may cache adverts, materialize the receipt stream into SQL, and
+serve fast queries. Because every record it serves is independently
+signed, an indexer can be stale, partial, or lying about *which* records
+exist — and cannot forge one. Two indexers disagreeing is a normal
+condition, not an incident; a buyer that doubts both queries the network
+directly. Anything presented as network data is labelled an observed view.
+
+## Alternatives considered
+
+**Keep the control plane authoritative and market the network as
+decentralized.** Cheapest, and it is where the project already is. It
+fails the moment anyone checks, and "decentralized" claims that do not
+survive inspection are worse for the brand than not making them.
+
+**Go the other way: forbid hosted services entirely.** Ideologically
+tidy, commercially fatal, and worse for users. Onboarding, fiat billing,
+SLAs and observability are real needs; a protocol that cannot be wrapped
+in a managed service just gets wrapped in someone else's.
+
+**Rely on review discipline rather than a CI rule.** This is what
+DIP-0011 did. Three years of contributors and one deadline is all it takes
+for a Supabase import to land in a core crate with a good reason attached.
+
+## Migration & rollout
+
+Phase 0 (this DIP, docs, positioning) → Phase 1 (signed envelopes and
+native identity, DIP-0025) → Phase 2 (P2P market, `--gateway none` gate) →
+Phase 4 (Infernet control plane demoted to indexer/gateway). The Infernet
+control plane keeps working throughout; it loses authority in Phase 4 and
+becomes one of several ways to reach the network, not the way.
+
+Reverting is per-phase. Nothing here deletes a hosted service.
+
+## Open questions
+
+- Which crates are "core" as the tree grows — is `c0mpute-store` core, or
+  a service? Its content addressing looks protocol-shaped; its repair
+  scheduling does not.
+- What the CI dependency check runs on: a `cargo deny` ban list is the
+  obvious tool, but the interesting violations are HTTP calls to a
+  hardcoded host, which it will not catch.
+
+## Out of scope
+
+- Whether to build the commercial layer, and what it charges. That is
+  §19-20 of the v2 direction and a separate decision.
+- Token issuance and on-chain consensus. Not proposed, not required.
+- The Infernet migration mechanics; Phase 4 gets its own DIP.

--- a/dips/v2.x/0025-signed-envelopes-and-native-identity.md
+++ b/dips/v2.x/0025-signed-envelopes-and-native-identity.md
@@ -1,0 +1,222 @@
+---
+dip: 0025
+title: "Give every protocol message its own signature and every peer its own DID"
+status: Draft
+authors:
+  - anthony@profullstack.com
+created: 2026-09-07
+updated: 2026-09-07
+discussion:
+implementation: node/crates/c0mpute-envelope
+supersedes:
+superseded-by:
+---
+
+## Summary
+
+Four things change:
+
+1. **Native network identity.** Every peer has a locally generated
+   `did:c0mpute:z6Mk…` derived from the ed25519 key libp2p already
+   persists. Identity is established offline, with no account anywhere and
+   no payment product involved.
+2. **Signed envelopes.** Every protocol message travels in an envelope
+   carrying its own detached signature over canonical bytes, with domain
+   separation by message type. Verification needs no registry lookup and
+   no network round trip.
+3. **Canonical serialization.** RFC 8785 with floats and non-ASCII object
+   keys forbidden, so two implementations in two languages produce
+   byte-identical output — and therefore identical hashes and signatures.
+4. **Four payload types**: `provider.advert/v1`, `job/v2`, `offer/v1`,
+   `receipt/v1` (plus `receipt.acceptance/v1` for the buyer's
+   countersignature).
+
+Implemented in `node/crates/c0mpute-envelope`, with pinned cross-
+implementation test vectors in that crate's `tests/vectors.rs`.
+
+## Motivation
+
+### Transport signatures do not survive the first hop
+
+The v1 market types in `c0mpute-net::topics` carry no signature. Their
+comment says so plainly: *"Signed by the worker's CoinPay DID once that
+lands; today we rely on gossipsub message authenticity."* That is fine
+while a message is on the wire and useless everywhere else:
+
+- an advert relayed by an indexer arrives with no provenance;
+- a receipt read back from local disk after a restart cannot be checked;
+- an offer forwarded by a gateway is the gateway's word;
+- a reputation score computed from any of the above has to be *believed*,
+  which is exactly the property that forces a trusted database into the
+  middle of the network.
+
+Signed receipts are the difference between reputation being portable and
+reputation being someone's table.
+
+### Identity should not require a payment product
+
+DIP-0007 makes CoinPay DIDs the identity layer. CoinPay is the right
+default and the best-integrated option, and it should stay that way. But
+binding *network identity* to it means a node cannot advertise capacity,
+be discovered, or verify a peer without a second product's availability —
+and it means any organization that wants a different settlement rail has
+to argue with the identity layer to get one.
+
+Splitting them costs almost nothing (the key already exists, for libp2p)
+and buys: offline identity creation, a working network when CoinPay is
+unreachable, and settlement as a named adapter rather than an assumption.
+
+### Floats and timestamps quietly fork a network
+
+Two nodes that serialize the same logical message differently compute
+different hashes and cannot verify each other's signatures. The two
+reliable ways to get there are floating-point numbers (`0.1 + 0.2`, and
+every encoder's disagreement about how to print a double) and timestamps
+with more than one legal spelling. Both are avoidable by construction, and
+neither is recoverable once signed data is in the wild.
+
+## Detailed design
+
+Full specification in `docs/protocol/`. The load-bearing decisions:
+
+### Identity: `did:c0mpute:z…`, byte-compatible with `did:key`
+
+```text
+did:c0mpute:z6MkswFb62xmEDrqnknM3TP112AiH6A5YETp7gc2Qz4Wqkar
+            └ multibase base58btc of (0xed 0x01 ‖ 32-byte ed25519 public key)
+```
+
+The encoding after `z` is identical to `did:key` for ed25519, so existing
+DID tooling resolves a c0mpute identity by swapping the method name. Same
+key as the libp2p peer id, so a node has one identity across transport and
+protocol rather than two that can disagree.
+
+Credentials — CoinPay wallet, KYB, hardware attestation, organization
+membership, SLA — attach to this key as separate assertions. None is
+required to join.
+
+### Envelope
+
+```json
+{
+  "v": 1,
+  "type": "c0mpute.provider.advert/v1",
+  "signer": "did:c0mpute:z6Mk…",
+  "payload": { },
+  "sig": "z5p6…"
+}
+```
+
+The signature covers `"c0mpute-envelope/v1\n" ‖ type ‖ "\n" ‖
+canonical_json({v, type, signer, payload})`. Domain separation by tag and
+by type means a signature harvested from one message type cannot be
+replayed as another — including between two types with identical field
+shapes, which is a test in the crate.
+
+`Envelope::open()` checks version, type, signature and payload structure
+before returning the payload. Reading `.payload` directly is the mistake
+this design exists to prevent, and everything downstream should go through
+`open()` so that "we received this" and "this peer signed this" stay the
+same statement.
+
+### Canonical JSON: RFC 8785, minus its two hardest corners
+
+- **No floats.** Money is a decimal string (`"0.042"`); durations and
+  sizes are integers bounded to the safe-integer range so a browser client
+  and a Rust node agree. Canonicalization *rejects* a float rather than
+  guessing, so the failure is at signing time, not on someone else's
+  verification.
+- **ASCII object keys.** JCS sorts by UTF-16 code unit, which diverges
+  from UTF-8 byte order above U+FFFF; restricting keys makes the two
+  orderings identical. Values remain full UTF-8.
+
+Both are checked, not assumed.
+
+### Content addressing and BLAKE3
+
+Job ids and record references are content hashes, written `blake3:<hex>`
+and resolvable as `c0://blake3:<hex>`. The v2 direction's illustrative
+JSON writes `sha256:`; the repository already content-addresses chunks
+with BLAKE3 (`c0mpute-proto::Hash`, `c0mpute://blake3:`), and running two
+hash trees over the same bytes would be a lasting tax for no gain. The
+algorithm is on the wire, so this is a default, not a lock-in.
+
+A job's id is the hash of its whole canonical manifest. The v2 direction
+sketches an `id` field *inside* the manifest, which obliges every
+implementation to agree on which fields to strip before hashing; deriving
+it from the whole document deletes that step and its bugs.
+
+### Two signatures, two envelopes
+
+A receipt needs the provider's signature and the buyer's. Rather than a
+multi-signature blob, the provider seals a `receipt/v1` and the buyer
+seals a `receipt.acceptance/v1` naming it by hash. The signatures are made
+at different times by parties who may never be online together, one
+arriving without the other is normal rather than malformed, and a buyer
+can say *no* — which a countersignature field cannot express.
+
+### Freshness is a read-time check
+
+Adverts and offers carry expiry; adverts are capped at 15 minutes.
+`open()` verifies authenticity, `open_fresh(now)` also enforces expiry.
+The split is deliberate: an expired advert is history, not a forgery, and
+a stale cache should stop looking like live capacity without stale records
+becoming unverifiable.
+
+## Alternatives considered
+
+**Keep leaning on gossipsub signatures.** Zero work, and it forecloses
+portable reputation, offline verification, and any non-gossip transport.
+The v1 comment already anticipated replacing this.
+
+**Use CoinPay DIDs as network identity (status quo, DIP-0007).** Fewer
+moving parts and a genuine integration advantage. Rejected because it puts
+a payment product in the path of peer discovery and makes settlement
+choice an identity-layer argument. CoinPay remains the default adapter and
+the first-party integration; it is no longer load-bearing for the network
+to run.
+
+**Protobuf or CBOR instead of canonical JSON.** Both have canonical forms
+and both are more compact. JSON wins here because agents, browsers and
+`curl` are first-class clients (v2 direction §23), a signed message should
+be readable by the person debugging it, and the deterministic-encoding
+problem is solved either way. Revisit if message volume ever makes size
+the binding constraint.
+
+**Full RFC 8785 including float canonicalization.** Correct and portable
+in principle; in practice implementing ECMAScript `Number::toString`
+exactly, in every client language, is a bug factory in the one place bugs
+are unrecoverable. Forbidding floats costs a string field for money.
+
+## Migration & rollout
+
+`c0mpute-envelope` lands alongside the v1 types in `c0mpute-net::topics`,
+which keep working. Phase 2 ports the market path onto the new types and
+the v1 types are removed once nothing publishes them. There is no dual-
+signing window: the two formats are different message types on different
+topics, so a node speaking only one is simply not a peer for the other.
+
+Reverting means not adopting the new topics; nothing existing changes
+behaviour on this DIP alone.
+
+## Open questions
+
+- **Key rotation.** The DID is the key, so rotating it drops the peer's
+  receipt history. A signed rotation record linking old to new is the
+  obvious answer and is not designed yet.
+- **Advert lifetime.** 15 minutes is a guess balancing re-signing cost
+  against stale capacity. Testnet churn data should set it.
+- **Credential verification.** `Credential` carries a type, an issuer and
+  a reference; how a buyer *checks* one is deliberately unspecified until
+  there is a second credential type to generalize from.
+
+## Out of scope
+
+- Discovery, gossip topic layout, and relay/NAT traversal (Phase 2).
+- Buyer-side scheduling policy. The crate implements the checks where
+  accepting an offer would be a *bug*; price/latency/reputation weighting
+  is policy and lives in the scheduler.
+- Reputation scoring itself. This DIP makes receipts verifiable so that
+  scoring can be derived and disagreed with; it does not pick a formula.
+- The settlement adapter interface. `SettlementAdapter` names the rail on
+  the wire; what an adapter must *do* is its own DIP.

--- a/docs/c0mpute-v1.md
+++ b/docs/c0mpute-v1.md
@@ -1,5 +1,13 @@
 # c0mpute.com v1 Augmentation PRD
 
+> **Superseded where it conflicts with the v2 direction.** c0mpute v2 makes
+> the network a protocol and open marketplace rather than a fleet plus
+> plugins, and no hosted service may be authoritative for protocol
+> correctness (DIP-0024). Where this document assumes a coordinator, a
+> central scheduler, or CoinPay as the identity layer, the v2 direction and
+> `docs/protocol/` win. Everything else here — the module model, the
+> workload verticals, the pricing work — carries forward unchanged.
+
 ## Status
 
 Draft augmentation PRD for steering the existing p2p compute work toward the new c0mpute.com direction before implementation goes too far in the wrong direction.

--- a/docs/protocol/README.md
+++ b/docs/protocol/README.md
@@ -1,0 +1,112 @@
+# The c0mpute protocol
+
+**Status:** Phase 1. Envelopes, identity and the four message types are
+specified and implemented. Discovery, scheduling, relays, settlement
+adapters and reputation are named here but not yet written — the pages
+that do not exist yet are listed at the bottom rather than stubbed, so
+nothing in this directory describes code that has not been built.
+
+> c0mpute.com infrastructure is not required for the c0mpute network to
+> operate.
+
+That sentence is the point of this directory. Everything below is designed
+so that two peers who have never heard of us can find each other, agree on
+a price, run work, check the result and settle — and so that anyone
+holding the resulting records can verify them without asking us, or
+anyone, for permission.
+
+## Read this first: four kinds of thing
+
+Every component of c0mpute is exactly one of these, and mixing them up is
+how a decentralized network quietly acquires a single point of failure
+(DIP-0024):
+
+| | meaning |
+|---|---|
+| **protocol requirement** | an implementation MUST do this to interoperate |
+| **reference implementation** | how *we* do it; another node may differ |
+| **optional hosted service** | an accelerator; the network works without it |
+| **first-party integration** | our product, best-supported, never mandatory |
+
+Indexers, gateways, dashboards, relays and the Infernet control plane are
+all in the third column. They may cache, observe, proxy and bill. None of
+them is authoritative: none may be *required* for two honest peers to
+transact.
+
+## The message types
+
+Four signed records carry the market. Each is self-contained — everything
+needed to verify it is inside it.
+
+```text
+c0mpute.provider.advert/v1    a provider says what it can run, and until when
+c0mpute.job/v2                a buyer describes work, constraints, price, trust
+c0mpute.offer/v1              a provider quotes a binding price for one job
+c0mpute.receipt/v1            the provider signs what actually happened
+c0mpute.receipt.acceptance/v1 the buyer countersigns, or disputes
+```
+
+They chain by content hash, so no participant has to be trusted to report
+the previous step honestly:
+
+```text
+  provider.advert ──┐
+                    ├──> offer ──> receipt ──> acceptance
+  job ──────────────┘      │          │            │
+   │                       │          │            │
+   └── job id ─────────────┴──────────┘            │
+       (hash of the manifest)                      │
+                          offer hash ──────────────┘
+                                     receipt hash
+```
+
+An offer names the job it bids on *and* the advert it is backed by. A
+receipt names the job and the offer that priced it. An acceptance names
+the receipt. Every arrow is a hash, so a third party holding the JSON can
+check that the price paid is the price quoted, and that the quote came
+from a provider that claimed the capabilities relied on.
+
+## Pages
+
+| page | what it fixes |
+|---|---|
+| [canonical-json.md](canonical-json.md) | the exact bytes a signature covers |
+| [identity.md](identity.md) | `did:c0mpute:z…`, and why identity is not payment |
+| [envelopes.md](envelopes.md) | the signed wrapper, and domain separation |
+| [providers.md](providers.md) | `provider.advert/v1` |
+| [jobs.md](jobs.md) | `job/v2` |
+| [offers.md](offers.md) | `offer/v1` |
+| [receipts.md](receipts.md) | `receipt/v1`, acceptance, and derived reputation |
+
+## Implementation
+
+`node/crates/c0mpute-envelope` is the reference implementation. It depends
+on no transport, no HTTP client and no settlement product — identity
+enters as raw ed25519 bytes and settlement is named by an open string.
+That is what makes DIP-0024's dependency rule checkable rather than
+aspirational.
+
+Cross-implementation test vectors are pinned in that crate's
+`tests/vectors.rs`. A second implementation is correct when it reproduces
+those DIDs and hashes exactly. To print them:
+
+```sh
+cargo test -p c0mpute-envelope --test vectors -- --nocapture print_vectors
+```
+
+## Not yet written
+
+These are real parts of the v2 direction with no specification here,
+because there is no implementation to specify:
+
+- **discovery** — DHT provider lookup and gossip topic layout (Phase 2)
+- **scheduling** — buyer-side offer scoring policies (Phase 2)
+- **relays** — NAT traversal and outbound-only providers (Phase 2)
+- **settlement** — what a settlement adapter must do (Phase 3)
+- **reputation** — deriving scores from receipts (Phase 3)
+- **validation** — the L0–L5 tiers as a wire contract (Phase 3)
+
+`ValidationPolicy` and `SettlementAdapter` already travel in `job/v2` and
+`receipt/v1`, so a job can *state* its validation level and settlement
+rail today. What an implementation must do to honour either is the part
+still missing.

--- a/docs/protocol/canonical-json.md
+++ b/docs/protocol/canonical-json.md
@@ -1,0 +1,97 @@
+# Canonical JSON
+
+**Protocol requirement.**
+
+A signature covers bytes, not meaning. If a Rust node and a browser client
+serialize the same logical message differently, they compute different
+hashes, fail to verify each other's signatures, and quietly stop being the
+same network. Canonicalization is what stops that.
+
+c0mpute uses **RFC 8785 (JCS)** with two restrictions that remove its
+hardest corners. Both are *checked*, not assumed: a payload that violates
+one fails to canonicalize, so the error lands at signing time rather than
+on someone else's verification.
+
+## The rules
+
+1. **Objects**: keys sorted, ascending, by their raw bytes.
+2. **Arrays**: order preserved.
+3. **No insignificant whitespace** anywhere.
+4. **Strings**: `"` and `\` escaped; `\b \f \n \r \t` use their short
+   forms; other characters below `U+0020` use lowercase `\u00xx`;
+   everything else is emitted as literal UTF-8.
+5. **No floating-point numbers.** *(restriction)*
+6. **Object keys must be ASCII.** *(restriction)*
+7. Integers must satisfy `|n| ≤ 2^53 − 1`.
+
+## Why no floats
+
+JCS canonicalizes doubles through the ECMAScript `Number::toString`
+algorithm. It is well-specified and genuinely hard to reimplement exactly,
+in every client language, in the one place where a bug is unrecoverable:
+once a wrong hash has been signed and gossiped, there is no fixing it
+after the fact.
+
+The cost of avoiding it is one string field:
+
+```json
+"price": { "amount": "0.042", "currency": "USD" }
+```
+
+`0.1 + 0.2 != 0.3` in binary floating point, and encoders disagree about
+how to print a double. Money as a decimal string sidesteps both. Durations
+and sizes are integers. Nothing in a signed c0mpute payload is a float,
+and the canonicalizer rejects one rather than guessing.
+
+The `2^53 − 1` bound exists for the same reason from the other direction:
+a JSON parser backed by JavaScript numbers silently loses precision above
+it. Anything larger belongs in a string.
+
+## Why ASCII keys
+
+JCS sorts object keys by UTF-16 code unit. Above `U+FFFF` that ordering
+diverges from UTF-8 byte order, so an implementation that sorts raw bytes
+— the obvious thing to do — is subtly wrong for a narrow range of keys it
+will probably never see, which is the worst kind of bug to own.
+
+Restricting *keys* to ASCII makes the two orderings identical. **Values
+are unrestricted UTF-8**: `{"note":"café ☕"}` is fine, `{"café":1}` is
+not. Wire field names are all camelCase ASCII anyway.
+
+## Worked example
+
+Input, with keys in an arbitrary order and a nested object:
+
+```json
+{
+  "z": { "second": 2, "first": 1 },
+  "a": [ { "y": 1, "x": 2 } ]
+}
+```
+
+Canonical form:
+
+```json
+{"a":[{"x":2,"y":1}],"z":{"first":1,"second":2}}
+```
+
+Note that the *array* keeps its order while the objects inside it are
+sorted.
+
+## What this buys
+
+Because canonicalization is deterministic, a content hash is a stable name
+for a record. Two nodes that received the same envelope compute the same
+hash, so an offer can cite a job by hash, a receipt can cite an offer, and
+none of them has to re-send the thing they are citing or be trusted about
+its contents.
+
+It also means a record survives a round trip through storage. Serialize
+canonically, read back, re-hash: same answer. That is what lets a buyer
+rebuild local job state from an on-disk event log after a restart, with no
+database and no server to ask.
+
+## Reference
+
+`node/crates/c0mpute-envelope/src/canonical.rs`. The rules above are each
+covered by a test in that file.

--- a/docs/protocol/envelopes.md
+++ b/docs/protocol/envelopes.md
@@ -1,0 +1,121 @@
+# Envelopes
+
+**Protocol requirement.**
+
+Every c0mpute protocol message travels in a signed envelope:
+
+```json
+{
+  "v": 1,
+  "type": "c0mpute.provider.advert/v1",
+  "signer": "did:c0mpute:z6MkswFb62xmEDrqnknM3TP112AiH6A5YETp7gc2Qz4Wqkar",
+  "payload": { },
+  "sig": "z5p6RP1aX1ZAeffARCUXgBAJ12RBphawNMKnSQLhF4UWU9T8RXE5BUyALwFJqYvzHQP6kuYwCFAfckividdjCHL5B"
+}
+```
+
+| field | |
+|---|---|
+| `v` | envelope format version, currently `1` |
+| `type` | payload type identifier |
+| `signer` | the DID that vouched for the payload |
+| `payload` | the message |
+| `sig` | detached signature over the domain-separated canonical bytes |
+
+## Why an envelope, when gossipsub already signs messages
+
+Because a transport signature dies at the first hop.
+
+libp2p signs each pubsub message with the publisher's key, which is
+sufficient for exactly as long as the message is on the wire. It does not
+help with:
+
+- an advert **relayed by an indexer** — arrives with no provenance;
+- a receipt **read back from local disk** after a restart;
+- an offer **forwarded by a gateway** — the gateway's word;
+- a record shown to **a third party** who was not on the wire at all.
+
+The v1 market types in `c0mpute-net::topics` carry no signatures of their
+own and rely on transport authenticity. That is precisely what makes
+reputation non-portable: a score computed from unverifiable receipts has
+to be *believed*, which means a trusted database ends up in the middle of
+a network that is supposed not to need one.
+
+An envelope makes a record verifiable by anyone holding it, forever,
+without asking anybody.
+
+## The signing input
+
+```text
+"c0mpute-envelope/v1\n" ‖ type ‖ "\n" ‖ canonical_json({v, type, signer, payload})
+```
+
+Two layers of domain separation:
+
+- the **tag** `c0mpute-envelope/v1\n` keeps a c0mpute signature from ever
+  being meaningful in another protocol that reuses the same key;
+- the **type**, prefixed *and* covered inside the canonical JSON, keeps a
+  signature harvested from one message type from being replayable as
+  another.
+
+That second one matters more than it looks. Two payload types can have
+identical field shapes — a `{"note": "…"}` in one type is byte-identical
+to a `{"note": "…"}` in another — and without type separation, lifting the
+signature from one and attaching it to the other would verify. The
+reference implementation tests exactly this case.
+
+## Verification order
+
+`open()` checks, in order:
+
+1. **envelope version** — an unknown `v` is refused rather than guessed at;
+2. **payload type** — matches what the caller expected;
+3. **signature** — over the reconstructed signing input;
+4. **payload structure** — the payload's own validity rules.
+
+Only then is the payload returned. Nothing downstream should read
+`payload` directly: going through `open()` is what keeps "we received
+this" and "this peer signed this" the same statement.
+
+Structural validation also runs **before** signing. A signature is a claim
+that the signer stands behind the contents, and there is no reason to
+stand behind a payload already known to be malformed.
+
+## Freshness is separate from authenticity
+
+`open()` verifies. `open_fresh(now)` verifies *and* enforces the payload's
+own expiry.
+
+The split is deliberate. Adverts and offers expire; on a churning network
+that is the normal case, not an attack — a provider that loses power
+leaves its last advert sitting in every peer's cache. Rejecting expired
+records on read is what stops a stale cache from looking like live
+capacity. But an expired advert is **history, not a forgery**: it should
+still verify, because reconstructing what a provider claimed last Tuesday
+is a legitimate thing to do.
+
+Receipts never expire. A two-year-old receipt is exactly as valid a
+statement about the past as a fresh one.
+
+## Content hash
+
+An envelope's content hash is the BLAKE3 of its canonical JSON, written
+`blake3:<hex>`. Because canonicalization is deterministic and ed25519 is
+deterministic, two nodes holding the same envelope compute the same hash —
+so a record can be *cited* by hash without being re-sent, which is how
+offers reference jobs and receipts reference offers.
+
+Note the one asymmetry: a **job id** is the hash of the job manifest
+*payload*, not of its envelope. See [jobs.md](jobs.md#job-identity).
+
+## Versioning
+
+The envelope's `v` changes only for a breaking change to the envelope's
+own shape. Payload changes move the version inside the type identifier
+(`c0mpute.job/v2` → `c0mpute.job/v3`), which means a payload version bump
+is automatically a different domain-separation string — old signatures
+cannot carry over to a new payload version even by accident.
+
+## Reference
+
+`node/crates/c0mpute-envelope/src/envelope.rs`.

--- a/docs/protocol/identity.md
+++ b/docs/protocol/identity.md
@@ -1,0 +1,119 @@
+# Identity
+
+**Protocol requirement.**
+
+A c0mpute peer's identity is an ed25519 keypair, rendered as a DID:
+
+```text
+did:c0mpute:z6MkswFb62xmEDrqnknM3TP112AiH6A5YETp7gc2Qz4Wqkar
+            └ multibase base58btc of (0xed 0x01 ‖ 32-byte ed25519 public key)
+```
+
+It is **self-certifying**: the DID *is* the public key. Verifying a
+signature needs no registry, no lookup, and no network round trip. That
+property is doing most of the work in this protocol — it is why an
+indexer can be untrusted, why a receipt read off disk years later is still
+checkable, and why there is nothing to run that could refuse you an
+identity.
+
+## Generated locally, offline, with no account
+
+Running a c0mpute node creates a keypair on the machine. There is no
+registration, no server to reach, and no product to sign up for. The key
+is the same ed25519 key libp2p persists at `<config_dir>/identity.key`, so
+a node has one identity across transport and protocol rather than two that
+can drift apart.
+
+## Byte-compatible with `did:key`
+
+The encoding after `z` is exactly what `did:key` uses for ed25519 — the
+multicodec prefix `0xed 0x01` followed by the raw public key, base58btc
+with a multibase `z`. Any tooling that resolves `did:key:z6Mk…` resolves a
+c0mpute identity by swapping the method name.
+
+This is deliberate. The network needs a stable self-certifying
+identifier; it does not need a new registry, and inventing an encoding
+would have bought nothing but incompatibility.
+
+## Identity is not payment
+
+**This is a change from DIP-0007**, which made CoinPay DIDs the identity
+layer. CoinPay remains the default settlement adapter and the
+best-integrated one — see [receipts.md](receipts.md) — but it is no longer
+in the path of being *on* the network.
+
+The reason: binding network identity to a payment product means a node
+cannot advertise capacity, be discovered, or verify a peer without that
+product being reachable, and it makes "I want a different settlement rail"
+an argument with the identity layer. Splitting them costs nothing — the
+key already exists for libp2p — and buys offline identity creation, a
+network that works when CoinPay does not, and settlement as a named choice
+rather than an assumption.
+
+Credentials attach to the key as separate assertions:
+
+```text
+coinpay.wallet          a linked wallet and payment reputation
+coinpay.reputation      settlement history
+nostr.pubkey            a linked Nostr identity
+org.membership          organization membership
+kyb / kyc               identity verification, where a buyer requires it
+hardware.attestation    attested execution environment (validation L4)
+provider.verification   a verified-provider credential
+jurisdiction            a jurisdiction claim
+sla                     a service-level commitment
+```
+
+A credential names its type, its issuer, and where the evidence lives:
+
+```json
+{
+  "type": "coinpay.wallet",
+  "issuer": "did:c0mpute:z6Mk…",
+  "reference": "https://…"
+}
+```
+
+**None is required to join.** A fresh key with no credentials is a valid
+peer at the `community` trust tier, and a buyer who wants more decides
+that for themselves — see [providers.md](providers.md#trust-tiers). What
+is deliberately *not* specified yet is how a buyer verifies a credential;
+that generalizes badly from one example, and there is currently one.
+
+## Signatures
+
+Detached ed25519, wire-encoded as multibase base58btc to match the DID:
+
+```text
+"sig": "z5p6RP1aX1ZAeffARCUXgBAJ12RBphawNMKnSQLhF4UWU9T8RXE5BUyALwFJqYvzHQP6kuYwCFAfckividdjCHL5B"
+```
+
+ed25519 is deterministic, so signing the same payload with the same key
+twice gives the same bytes — which is what makes an envelope's content
+hash a stable name for it rather than something that changes each time it
+is re-signed.
+
+What gets signed, and how it is domain-separated, is in
+[envelopes.md](envelopes.md).
+
+## Test vectors
+
+Fixed seeds, for checking a second implementation. **Never use these for
+anything real.**
+
+| seed | DID |
+|---|---|
+| `0x11` × 32 | `did:c0mpute:z6MktULudTtAsAhRegYPiZ6631RV3viv12qd4GQF8z1xB22S` |
+| `0x77` × 32 | `did:c0mpute:z6MkswFb62xmEDrqnknM3TP112AiH6A5YETp7gc2Qz4Wqkar` |
+
+## Key rotation is unsolved
+
+The DID is the key, so rotating it drops the peer's entire receipt
+history. A signed rotation record linking the old identity to the new one
+is the obvious answer and is **not designed yet** (DIP-0025, open
+questions). Until it is, treat a c0mpute identity as long-lived and back
+up the key file.
+
+## Reference
+
+`node/crates/c0mpute-envelope/src/identity.rs`.

--- a/docs/protocol/jobs.md
+++ b/docs/protocol/jobs.md
@@ -1,0 +1,169 @@
+# `c0mpute.job/v2`
+
+**Protocol requirement.**
+
+The job manifest is the network's central portable abstraction, and the
+place where *buy execution, not machines* stops being a slogan.
+
+A manifest says what to run, what the provider must have, how much the
+buyer will pay, how the result gets checked, and who settles it. It does
+**not** name a provider, a scheduler, or a host. That absence is the
+design: the same manifest is schedulable by a local CLI, by a managed
+gateway the buyer explicitly delegated to, or by a private organization
+scheduler — and none of them is privileged over the others.
+
+## Example
+
+A real verified vector — requester seed `0x11` × 32, job id
+`blake3:4a4323c24e72bb676e575acb33051450e930e499b7b68d6a41ad7d47f5551b35`.
+Pretty-printed; the canonical form is compact.
+
+```json
+{
+  "v": 1,
+  "type": "c0mpute.job/v2",
+  "signer": "did:c0mpute:z6MktULudTtAsAhRegYPiZ6631RV3viv12qd4GQF8z1xB22S",
+  "payload": {
+    "workload": { "type": "infernet.inference", "version": ">=1 <2" },
+    "requester": "did:c0mpute:z6MktULudTtAsAhRegYPiZ6631RV3viv12qd4GQF8z1xB22S",
+    "requirements": {
+      "gpu": { "count": 1, "vramGiB": { "min": 24 }, "features": ["cuda"] },
+      "memoryGiB": { "min": 32 },
+      "region": ["us-west"],
+      "trustTier": "standard"
+    },
+    "input": {
+      "ref": "blake3:25905ca8fac0ba3d73174c28651036f55c62751fe8482bde2c766193417a57fb",
+      "encryption": "recipient-selected",
+      "bytes": 4096
+    },
+    "execution": {
+      "timeoutSeconds": 120,
+      "retry": 2,
+      "isolation": "container",
+      "runtimeDigest": "blake3:96eba7abacf8d50990a80b55e4b86374ff0f212d5441627cca6a28b6a506c550",
+      "network": false
+    },
+    "economics": {
+      "maxPrice": { "amount": "0.10", "currency": "USD" },
+      "settlement": "coinpay",
+      "escrow": true
+    },
+    "validation": { "level": "spotcheck", "redundancy": 1, "spotcheckPercent": 5 },
+    "output": { "retentionSeconds": 3600, "maxBytes": 10485760 },
+    "announcedAt": "2026-09-06T16:00:00.000Z",
+    "deadline": "2026-09-06T16:10:00.000Z"
+  },
+  "sig": "z3ieWJFJSdVpcQ8GKyh5YeaDyS2mkyJCcDidR8BruTQJLV2Wah6Haio2BzoJhxRSCQZsq31cWwbWRumAXaMyPN5B6"
+}
+```
+
+## Job identity
+
+**A job's id is the content hash of its canonical manifest** — the
+payload, not the envelope.
+
+The v2 direction sketches an `id` field *inside* the manifest. That forces
+every implementation to agree on which fields to strip before hashing, and
+a disagreement there means two nodes calling the same job by different
+names. Hashing the whole manifest deletes the step and its bugs.
+
+Hashing the payload rather than the envelope keeps the id stable
+independent of who sealed it — the manifest already names its requester,
+so it is bound to the buyer either way.
+
+```text
+job id = blake3(canonical_json(payload))
+```
+
+## Requester vs signer
+
+The manifest names its `requester`, and the envelope names its `signer`.
+They are normally the same identity, and an implementation must check
+that they are: an envelope proves *someone* signed the manifest, and only
+the comparison proves it was the buyer the manifest names.
+
+The field is carried in the payload rather than inferred from the envelope
+because a manifest quoted inside an offer or a receipt, stripped of its
+envelope, still needs to say where it came from.
+
+## Fields
+
+| field | required | |
+|---|---|---|
+| `workload.type` | yes | namespaced workload, e.g. `infernet.inference` |
+| `workload.version` | no | semver range, e.g. `">=1 <2"` |
+| `requester` | yes | must match the envelope signer |
+| `requirements` | no | eligibility constraints; see below |
+| `input` | no | content-addressed input; omitted for jobs with none |
+| `execution` | yes | timeout, retries, isolation, runtime pin |
+| `economics` | yes | price cap, settlement rail, escrow |
+| `validation` | no | defaults to schema validation, redundancy 1 |
+| `output` | no | defaults to 1 hour retention, 10 MiB |
+| `announcedAt` / `deadline` | yes | the scheduling window |
+
+## Input is content-addressed
+
+```json
+"input": { "ref": "blake3:2590…", "encryption": "recipient-selected" }
+```
+
+A content hash rather than a mutable URL. The provider can verify it
+fetched what the buyer signed for, and the bytes can be served by a local
+cache, a c0mpute storage provider, or an HTTP gateway without changing the
+manifest or its id. The same hash written as a URI is
+`c0://blake3:2590…` — it names no host, which is what lets it survive any
+one host disappearing.
+
+`encryption` absent means plaintext. Appropriate for public inputs; not
+for private work.
+
+## Execution defaults are conservative
+
+```json
+{ "isolation": "container", "network": false, "retry": 0 }
+```
+
+Network access is **off unless asked for**, and isolation defaults to a
+container. A provider running untrusted work should have to opt in to
+loosening either. `runtimeDigest` pins the image or plugin artifact by
+digest — with the input hash, that is what makes a result reproducible by
+a third party: *this input, through exactly this code, produced this
+output*.
+
+Retries are capped at 10, and the timeout must fit inside the window
+between `announcedAt` and `deadline` — a manifest that cannot possibly
+complete in time is rejected at signing rather than discovered by a
+provider that already started work.
+
+## Settlement is named, not assumed
+
+```json
+"settlement": "coinpay"
+```
+
+An open string. `coinpay` is the default and the first-party integration;
+`x402`, `lightning`, `invoice`, `gateway-credits` and `private` are
+recognized names, and an unknown lowercase-kebab value is valid — a
+settlement rail nobody has built yet still travels correctly today.
+
+This is the mechanism that keeps protocol adoption from being contingent
+on adopting one payment product.
+
+## Trust and the `private` tier
+
+`requirements.trustTier` filters providers ([see
+providers.md](providers.md#trust-tiers)). One rule is enforced rather than
+documented: the `private` tier **requires** a non-empty `providers`
+allowlist. Without one it silently degrades into "any provider that claims
+the private tier", which is the opposite of what the buyer asked for.
+
+## Deadlines
+
+A job past its `deadline` is not schedulable, and offers referencing it
+should be dropped. Verification still succeeds — the manifest is a record
+of what was asked for, and that does not stop being true.
+
+## Reference
+
+`node/crates/c0mpute-envelope/src/job.rs`.

--- a/docs/protocol/offers.md
+++ b/docs/protocol/offers.md
@@ -1,0 +1,102 @@
+# `c0mpute.offer/v1`
+
+**Protocol requirement.**
+
+An offer is a provider's binding quote for one specific job, and it is
+where the v2 direction's central architectural claim gets cashed out:
+
+> The offer is **signed by the provider** and **selected by the buyer**.
+> Nothing in between decides.
+
+A gateway may collect offers on a buyer's behalf. An indexer may have
+suggested which providers to ask. Neither can manufacture an offer, and
+neither gets to pick.
+
+## Example
+
+A real verified vector — signer seed `0x77` × 32, hash
+`blake3:9e9151a1d682f3c60fb596b92dad5757be890f476cf979dbe8c924228494393f`.
+
+```json
+{
+  "v": 1,
+  "type": "c0mpute.offer/v1",
+  "signer": "did:c0mpute:z6MkswFb62xmEDrqnknM3TP112AiH6A5YETp7gc2Qz4Wqkar",
+  "payload": {
+    "job": "blake3:4a4323c24e72bb676e575acb33051450e930e499b7b68d6a41ad7d47f5551b35",
+    "price": { "amount": "0.042", "currency": "USD" },
+    "expectedDurationMs": 12000,
+    "startBefore": "2026-09-06T16:02:00.000Z",
+    "expiresAt": "2026-09-06T16:00:10.000Z",
+    "capabilityAdvert": "blake3:cecfc7a08527ee50ab8945bb636afc940b5afff48a50cdfbcdee501edbebd2c2",
+    "coordinator": false
+  },
+  "sig": "z3J1bxFxvwCni6Hg6PHHas1wLCGLWNn1YrZNSNb4dH8nvQJFWg85FgqKeAYMkD1JTUVhhmHGBHuxrjrdunS1p8pfD"
+}
+```
+
+## Fields
+
+| field | required | |
+|---|---|---|
+| `job` | yes | the job id being bid on |
+| `price` | yes | binding, unlike an advert's indicative rate |
+| `expectedDurationMs` | yes | must be > 0 |
+| `startBefore` | yes | the provider commits to starting by this instant |
+| `expiresAt` | yes | quote void after this; must be ≤ `startBefore` |
+| `capabilityAdvert` | no | the advert this quote is backed by, by hash |
+| `coordinator` | no | willing to coordinate a multi-provider job; default `false` |
+
+## The checks a buyer must not skip
+
+Three constraints where accepting a failing offer is simply a **bug**, not
+a policy choice:
+
+1. **Right job.** The offer's `job` matches the manifest's id.
+2. **Within the cap.** `price ≤ economics.maxPrice`, compared *by value*.
+   Lexically `"0.042" > "0.10"`; numerically it is not. A string
+   comparison here would reject good offers and accept `"0.9"` against a
+   `"0.10"` cap.
+3. **Fits the deadline.** `startBefore + expectedDurationMs ≤ deadline`.
+
+Currencies must match. There is no exchange rate at the protocol layer, so
+a cross-currency comparison is an **error**, never a silent `false` — the
+protocol must not guess a rate, and a buyer that meant to accept another
+currency should say so.
+
+Everything else — reputation, latency, provider diversity, jurisdiction,
+prior experience, validation cost — is **policy**, and lives in the
+scheduler rather than here. That is the split: this page defines what
+makes an offer *valid*, not what makes it *the best one*.
+
+## Offers go stale by construction
+
+A quote is a promise about capacity the provider has **now**. Letting it
+linger means bidding on hardware that is already busy, so
+`expiresAt` must not be later than `startBefore`: a quote you can still
+accept after its promised start time is not binding.
+
+The example above has a ten-second bid window against a two-minute start
+commitment, which is the shape to expect for interactive work.
+
+## `capabilityAdvert` ties price to claims
+
+Naming the backing advert by hash lets a buyer connect the price to the
+capabilities it was quoted against, and lets the eventual receipt record
+which claim of capacity was relied on. If a provider advertised 24 GiB of
+VRAM, quoted against that advert, and then failed the job, the record
+shows all three facts without anyone having to be believed.
+
+## `coordinator` is per-job, never a role
+
+A multi-provider workload — distributed inference, say — needs one
+participant to coordinate. A provider signals willingness per offer.
+
+The coordinator elected for one job has **no authority over any other
+job**. That is the whole difference between an ephemeral coordinator and a
+control plane, and it is why the flag lives on an individual offer rather
+than in a provider's advert or in a registry somewhere.
+
+## Reference
+
+`node/crates/c0mpute-envelope/src/offer.rs`.

--- a/docs/protocol/providers.md
+++ b/docs/protocol/providers.md
@@ -1,0 +1,152 @@
+# `c0mpute.provider.advert/v1`
+
+**Protocol requirement.**
+
+A provider's signed, short-lived claim about what it can run.
+
+Anyone holding an advert can check who made it and whether it is current,
+without asking a registry. That is what lets indexers cache adverts while
+remaining non-authoritative: an indexer can be stale, partial, or lying
+about *which* adverts exist — and cannot forge one. A buyer that doubts
+the index collects adverts off the network instead.
+
+## Example
+
+Canonical form is compact; pretty-printed here for reading. This is a real
+verified vector — signer seed `0x77` × 32, hash
+`blake3:cecfc7a08527ee50ab8945bb636afc940b5afff48a50cdfbcdee501edbebd2c2`.
+
+```json
+{
+  "v": 1,
+  "type": "c0mpute.provider.advert/v1",
+  "signer": "did:c0mpute:z6MkswFb62xmEDrqnknM3TP112AiH6A5YETp7gc2Qz4Wqkar",
+  "payload": {
+    "sequence": 8472,
+    "issuedAt": "2026-09-06T23:50:00.000Z",
+    "expiresAt": "2026-09-06T23:59:00.000Z",
+    "capabilities": {
+      "cpu": { "arch": "x86_64", "cores": 32 },
+      "memoryGiB": 128,
+      "gpus": [
+        {
+          "vendor": "nvidia",
+          "family": "ada",
+          "vramGiB": 24,
+          "features": ["cuda", "nvenc"],
+          "count": 1
+        }
+      ],
+      "storageGiB": 1200,
+      "bandwidthMbps": 1000,
+      "workloads": ["infernet.inference", "transcode.ffmpeg"]
+    },
+    "pricing": [
+      {
+        "workload": "infernet.inference",
+        "unit": "1m-output-tokens",
+        "price": { "amount": "0.60", "currency": "USD" }
+      }
+    ],
+    "trust": { "tier": "standard" },
+    "disclosure": { "region": "us-west" }
+  },
+  "sig": "z5p6RP1aX1ZAeffARCUXgBAJ12RBphawNMKnSQLhF4UWU9T8RXE5BUyALwFJqYvzHQP6kuYwCFAfckividdjCHL5B"
+}
+```
+
+## Fields
+
+| field | required | |
+|---|---|---|
+| `sequence` | yes | monotonic counter; a peer holding two adverts from one provider keeps the higher |
+| `issuedAt` / `expiresAt` | yes | lifetime; capped at **15 minutes** |
+| `capabilities.cpu` | yes | `arch` and `cores` (≥ 1) |
+| `capabilities.memoryGiB` | yes | |
+| `capabilities.gpus` | no | accelerators; `count` defaults to 1 |
+| `capabilities.storageGiB` | no | |
+| `capabilities.bandwidthMbps` | no | |
+| `capabilities.workloads` | yes | ≥ 1, unique, namespaced |
+| `pricing` | no | indicative rates; every priced workload must be advertised |
+| `trust.tier` | yes | see below |
+| `trust.credentials` | no | assertions others have made |
+| `disclosure` | no | opt-in region / country / ASN |
+
+## Adverts expire fast
+
+Fifteen minutes, maximum, enforced at signing. A residential provider that
+loses power leaves its last advert in every peer's cache; a short lifetime
+is what stops that cache from looking like live capacity. The cost is
+re-signing every few minutes, which is one ed25519 operation.
+
+An expired advert still *verifies* — see
+[envelopes.md](envelopes.md#freshness-is-separate-from-authenticity).
+
+## Workload namespaces
+
+Lowercase, dot-separated, at least two segments: `transcode.ffmpeg`,
+`infernet.inference`, `whisper.transcribe`, `oci.container`. A bare verb
+(`transcode`) is rejected, because unqualified names are exactly what
+different plugins would each interpret their own way.
+
+Advertising a workload is **acceptance policy**, not capability alone.
+Advertising `whisper.transcribe` and refusing `oci.container` is the
+normal, expected posture for a machine its owner also uses for other
+things.
+
+## Pricing is indicative
+
+Rates in an advert are what a buyer *filters* on. The binding number is
+the one in a signed [offer](offers.md). A rate names a workload, a unit,
+and a price:
+
+```json
+{ "workload": "infernet.inference", "unit": "1m-output-tokens",
+  "price": { "amount": "0.60", "currency": "USD" } }
+```
+
+Units are an open string — `gpu-second`, `cpu-core-second`, `video-minute`,
+`audio-minute`, `1m-input-tokens`, `1m-output-tokens`, `image`, `gb-month`,
+`gb-transferred`, `request`, `reserved-capacity-hour`, `job`. Plugins
+define their own; the protocol carries a unit without needing to know what
+it means.
+
+Prices are decimal **strings**, never floats
+([canonical-json.md](canonical-json.md#why-no-floats)).
+
+## Trust tiers
+
+A tier is a **claim**, and a buyer's policy decides which claims it
+credits. The network does not adjudicate.
+
+| tier | |
+|---|---|
+| `community` | cryptographic identity only; no KYC; low-value work |
+| `standard` | established receipt history, minimum success rate |
+| `verified` | provider credential, hardware verification where available |
+| `private` | on a specific buyer's allowlist |
+| `enterprise` | organization verification, SLA, jurisdiction controls |
+
+Matching is by strength, with one exception: `private` and `enterprise`
+mean *"on this list"*, so they satisfy only themselves. A `verified`
+provider can take `standard` work; it cannot take `private` work by being
+strong, because that would defeat what `private` means.
+
+`community` is the default. A fresh key with no history is honestly
+described by it.
+
+## Disclosure is opt-in
+
+Every field under `disclosure` is a choice, and absent means **"not
+saying"** — never "unknown". Publishing none of it is a supported way to
+run a provider; the consequence is simply that a buyer requiring a region
+cannot match you.
+
+Related privacy defaults: no hostname, no exact location, no raw process
+list, no unnecessary OS fingerprint. GPUs are described by vendor, family
+and feature strings rather than exact model — which also keeps the
+protocol from having to learn every new SKU.
+
+## Reference
+
+`node/crates/c0mpute-envelope/src/advert.rs`.

--- a/docs/protocol/receipts.md
+++ b/docs/protocol/receipts.md
@@ -1,0 +1,178 @@
+# `c0mpute.receipt/v1`
+
+**Protocol requirement.**
+
+A receipt is the network's durable record of what happened, and the input
+to every reputation calculation.
+
+> **Reputation is derived, not stored.**
+
+There is no global score and no authoritative table holding one. A peer
+that has collected receipts computes a provider's completion rate, dispute
+rate and offer accuracy for itself, and two peers weighting those
+differently are both correct. That is what makes reputation survive an
+operator's database going away — or an operator deciding it does not like
+you.
+
+## Example
+
+A real verified vector — signer seed `0x77` × 32, hash
+`blake3:7c5ba273a840b6bfd859f24904e032229010cee3de67c4102e194d3c558e87df`.
+
+```json
+{
+  "v": 1,
+  "type": "c0mpute.receipt/v1",
+  "signer": "did:c0mpute:z6MkswFb62xmEDrqnknM3TP112AiH6A5YETp7gc2Qz4Wqkar",
+  "payload": {
+    "job": "blake3:4a4323c24e72bb676e575acb33051450e930e499b7b68d6a41ad7d47f5551b35",
+    "offer": "blake3:9e9151a1d682f3c60fb596b92dad5757be890f476cf979dbe8c924228494393f",
+    "buyer": "did:c0mpute:z6MktULudTtAsAhRegYPiZ6631RV3viv12qd4GQF8z1xB22S",
+    "provider": "did:c0mpute:z6MkswFb62xmEDrqnknM3TP112AiH6A5YETp7gc2Qz4Wqkar",
+    "workload": "infernet.inference",
+    "inputHash": "blake3:25905ca8fac0ba3d73174c28651036f55c62751fe8482bde2c766193417a57fb",
+    "outputHash": "blake3:4ceae457499f31d30cdc14ecf51de929a384100db61a782bbcae38cc7f99a401",
+    "runtimeHash": "blake3:96eba7abacf8d50990a80b55e4b86374ff0f212d5441627cca6a28b6a506c550",
+    "startedAt": "2026-09-06T16:01:00.000Z",
+    "completedAt": "2026-09-06T16:01:12.000Z",
+    "price": { "amount": "0.042", "currency": "USD" },
+    "validation": {
+      "policy": { "level": "spotcheck", "redundancy": 1, "spotcheckPercent": 5 },
+      "status": "accepted"
+    },
+    "settlement": {
+      "adapter": "coinpay",
+      "reference": "cp_rcpt_01J8Z3",
+      "settled": true
+    }
+  },
+  "sig": "z2F57B4GSYCWbNuayafMTWWyKELs3ZwwL6gXwx9XWctioRnbXWimiKDK8RUSwjDm5pgSvUb3nbD8HieQiSDwn3tRH"
+}
+```
+
+## Fields
+
+| field | required | |
+|---|---|---|
+| `job` | yes | the job id |
+| `offer` | yes | the offer that set the price, by hash |
+| `buyer` / `provider` | yes | must differ |
+| `validator` | no | the independent validator, at levels L2 and up |
+| `workload` | yes | namespaced workload |
+| `inputHash` | no | what went in |
+| `outputHash` | no | what came out; absent on failure |
+| `runtimeHash` | no | the pinned runtime that produced it |
+| `startedAt` / `completedAt` | yes | `completedAt` must not precede `startedAt` |
+| `price` | yes | what was charged |
+| `validation` | yes | the policy applied and what it concluded |
+| `settlement` | yes | adapter, external reference, and whether it settled |
+
+## Everything links by hash
+
+The receipt names the job **and** the offer that priced it. That is what
+makes the price checkable rather than assertable: a third party holding
+the offer and the receipt can confirm the amount charged is the amount
+quoted, by a provider that signed the quote before doing the work.
+
+With `inputHash` and `runtimeHash`, a receipt also states *this input,
+through exactly this code, produced this output* — which is what makes a
+result reproducible by someone who trusts none of the participants.
+
+## Failures are receipts too
+
+A timeout, a crash, or a provider withdrawal produces a receipt with no
+`outputHash` and a status of `failed`. A provider's failures are part of
+its record, and a network where only successes are signed has a reputation
+system that measures nothing.
+
+Two rules are enforced:
+
+- an `accepted` result **must** record an output hash;
+- `settled: true` is only valid alongside `accepted` — only accepted work
+  settles.
+
+## Validation status
+
+| status | |
+|---|---|
+| `accepted` | passed; the job should settle |
+| `rejected` | failed validation; no settlement |
+| `disputed` | the parties disagree; settlement held |
+| `failed` | no result to validate |
+
+The `policy` is repeated inside the receipt so that a reader holding only
+the receipt knows *how hard the result was actually checked*. "Accepted"
+under `requester` (L0) and "accepted" under `quorum` (L3) are very
+different claims, and a reputation calculation that treats them alike is
+wrong.
+
+## Settlement is recorded, not performed
+
+```json
+"settlement": { "adapter": "coinpay", "reference": "cp_rcpt_01J8Z3", "settled": true }
+```
+
+`reference` is the adapter's own identifier — a CoinPay receipt id, a
+Lightning payment hash, an invoice number. **Opaque on purpose**: the
+protocol records *that* an adapter settled and how to look it up, and
+knows nothing about any adapter's internals. That is what keeps a new
+settlement rail from being a protocol change.
+
+## Two signatures, two envelopes
+
+A receipt needs the provider's signature and the buyer's. Rather than one
+message carrying a `signatures` object, the provider seals the receipt and
+the buyer seals a separate `c0mpute.receipt.acceptance/v1` naming it by
+hash:
+
+```json
+{
+  "v": 1,
+  "type": "c0mpute.receipt.acceptance/v1",
+  "signer": "did:c0mpute:z6MktULudTtAsAhRegYPiZ6631RV3viv12qd4GQF8z1xB22S",
+  "payload": {
+    "receipt": "blake3:7c5ba273a840b6bfd859f24904e032229010cee3de67c4102e194d3c558e87df",
+    "accepted": true,
+    "signedAt": "2026-09-06T16:01:20.000Z"
+  },
+  "sig": "z5PDHRVens9NQoXoxc3ZgzBKm1hZVrwo4CYV5dyi1MZdrdDbE1kogourH4CRhaYmZHfNs1GDCrHKmtoQye36rFX2y"
+}
+```
+
+Three reasons for the split:
+
+- the signatures are made at different times by parties who may never be
+  online together, so **one arriving without the other is normal**, not a
+  malformed message;
+- a buyer needs to be able to say **no**, and a countersignature field has
+  no way to express a rejection;
+- both reuse one signing and verification path, so there is no second,
+  subtly different way to check a signature.
+
+A dispute (`accepted: false`) **must** state a reason. An unexplained
+dispute cannot be weighed against a provider's record, so allowing one
+would just be a free way to damage a provider.
+
+## Receipts never expire
+
+A two-year-old receipt is exactly as valid a statement about the past as a
+fresh one. Adverts and offers carry expiry; receipts deliberately do not.
+
+## Deriving reputation
+
+Not specified yet — see the [README](README.md#not-yet-written). What the
+receipt format makes *available* to a scorer:
+
+completed jobs · completion rate · failure rate · validation failures ·
+disputes · refunds · offer accuracy (quoted price vs charged) · latency
+accuracy (`expectedDurationMs` vs actual, both signed, one before the work
+and one after) · time on network · settlement history · validation level
+achieved.
+
+Latency and offer accuracy are the most useful and the hardest to fake:
+the quote was signed before the work and the receipt after it, so a
+provider that systematically under-quotes leaves a signed trail of it.
+
+## Reference
+
+`node/crates/c0mpute-envelope/src/receipt.rs`.

--- a/node/crates/c0mpute-envelope/Cargo.toml
+++ b/node/crates/c0mpute-envelope/Cargo.toml
@@ -1,0 +1,17 @@
+[package]
+name = "c0mpute-envelope"
+version.workspace = true
+edition.workspace = true
+license.workspace = true
+repository.workspace = true
+rust-version.workspace = true
+description = "Canonical serialization, native identity, and signed protocol envelopes for the c0mpute network"
+
+[dependencies]
+serde = { workspace = true }
+serde_json = { workspace = true }
+blake3 = { workspace = true }
+hex = { workspace = true }
+ed25519-dalek = { workspace = true }
+bs58 = { workspace = true }
+thiserror = { workspace = true }

--- a/node/crates/c0mpute-envelope/src/advert.rs
+++ b/node/crates/c0mpute-envelope/src/advert.rs
@@ -1,0 +1,478 @@
+//! `c0mpute.provider.advert/v1` — a provider says what it can run.
+//!
+//! An advert is a signed, short-lived, self-contained claim. Anyone
+//! holding one can check who made it and whether it is still current
+//! without asking a registry. That is what lets indexers cache adverts
+//! while remaining non-authoritative: an indexer can be stale or lying
+//! about *which* adverts exist, but it cannot forge one, and a buyer that
+//! doubts the index can collect adverts straight off the network instead.
+//!
+//! Adverts expire fast on purpose. A residential provider that loses power
+//! leaves its last advert sitting in every peer's cache; a short lifetime
+//! is what stops that cache from looking like live capacity.
+
+use serde::{Deserialize, Serialize};
+
+use crate::Error;
+use crate::envelope::Payload;
+use crate::identity::Did;
+use crate::types::{Money, Timestamp, TrustTier};
+
+/// Longest lifetime an advert may claim.
+///
+/// Long enough that a provider is not re-signing constantly, short enough
+/// that a dead provider drops out of the market within a coffee break.
+pub const MAX_ADVERT_LIFETIME_MS: i64 = 15 * 60 * 1000;
+
+/// A provider's signed capability advertisement.
+#[derive(Clone, Debug, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct ProviderAdvert {
+    /// Monotonic counter, incremented on every re-advert. A peer holding
+    /// two adverts from the same provider keeps the higher one — see
+    /// [`ProviderAdvert::supersedes`].
+    pub sequence: u64,
+    pub issued_at: Timestamp,
+    pub expires_at: Timestamp,
+    pub capabilities: ProviderCapabilities,
+    /// Indicative rates. The binding number is the one in a signed
+    /// `offer/v1`; this is what a buyer filters on before asking.
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub pricing: Vec<Rate>,
+    pub trust: ProviderTrust,
+    /// Opt-in disclosure. Absent means "not saying", never "unknown to the
+    /// provider" — a buyer that requires a region simply cannot match a
+    /// provider that withheld it.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub disclosure: Option<Disclosure>,
+}
+
+/// What a provider can execute, and how much of it.
+#[derive(Clone, Debug, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct ProviderCapabilities {
+    pub cpu: CpuSpec,
+    #[serde(rename = "memoryGiB")]
+    pub memory_gib: u32,
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub gpus: Vec<GpuSpec>,
+    #[serde(default)]
+    #[serde(rename = "storageGiB")]
+    pub storage_gib: u64,
+    #[serde(default)]
+    pub bandwidth_mbps: u32,
+    /// Workload namespaces this provider accepts, e.g.
+    /// `infernet.inference`, `transcode.ffmpeg`.
+    ///
+    /// Acceptance is per-provider policy: advertising `whisper.transcribe`
+    /// and refusing `oci.container` is the normal, expected posture for a
+    /// machine someone also uses for other things.
+    pub workloads: Vec<String>,
+}
+
+#[derive(Clone, Debug, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct CpuSpec {
+    /// `x86_64`, `aarch64`, …
+    pub arch: String,
+    pub cores: u32,
+}
+
+/// A GPU or other accelerator.
+///
+/// Described by family and feature strings rather than an exact model
+/// name: it keeps the protocol from having to learn every new SKU, and it
+/// is one less fingerprint on a home machine (§25).
+#[derive(Clone, Debug, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct GpuSpec {
+    /// `nvidia`, `amd`, `intel`, `apple`, …
+    pub vendor: String,
+    /// Architecture family, e.g. `ada`, `rdna3`, `m3`.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub family: Option<String>,
+    #[serde(rename = "vramGiB")]
+    pub vram_gib: u32,
+    /// Runtime features, e.g. `cuda`, `nvenc`, `rocm`, `metal`.
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub features: Vec<String>,
+    /// How many identical units. Defaults to 1.
+    #[serde(default = "one_u32")]
+    pub count: u32,
+}
+
+fn one_u32() -> u32 {
+    1
+}
+
+/// An indicative price for one workload, in one unit.
+#[derive(Clone, Debug, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct Rate {
+    /// Workload namespace this rate applies to.
+    pub workload: String,
+    /// A unit from §19.2, e.g. `gpu-second`, `1m-output-tokens`,
+    /// `video-minute`, `gb-month`. An open string: plugins define their
+    /// own units, and the protocol does not need to know what they mean to
+    /// carry them.
+    pub unit: String,
+    pub price: Money,
+}
+
+/// The trust position a provider claims for itself.
+///
+/// Claims, not proof. A buyer's policy decides which claims it credits and
+/// which credentials it verifies; the network does not adjudicate.
+#[derive(Clone, Debug, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct ProviderTrust {
+    pub tier: TrustTier,
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub credentials: Vec<Credential>,
+}
+
+impl Default for ProviderTrust {
+    fn default() -> Self {
+        // Community is the honest default: a fresh key with no history.
+        Self {
+            tier: TrustTier::Community,
+            credentials: Vec::new(),
+        }
+    }
+}
+
+/// An assertion some other identity has made about this provider.
+///
+/// Deliberately thin: a type, who said it, and where the evidence lives.
+/// Binding the protocol to one verifiable-credential format now would age
+/// worse than carrying a pointer.
+#[derive(Clone, Debug, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct Credential {
+    /// e.g. `coinpay.wallet`, `org.membership`, `hardware.attestation`,
+    /// `kyb`, `sla`.
+    #[serde(rename = "type")]
+    pub type_id: String,
+    /// The identity that issued it.
+    pub issuer: Did,
+    /// Where the credential document itself can be fetched or checked.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub reference: Option<String>,
+}
+
+/// Location and network facts a provider chose to publish.
+///
+/// Every field is optional and every field is a choice. Publishing none of
+/// it is a supported way to run a provider; a buyer that needs
+/// jurisdiction control simply will not match you.
+#[derive(Clone, Debug, Default, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct Disclosure {
+    /// Coarse region, e.g. `us-west`, `eu-central`.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub region: Option<String>,
+    /// ISO country code, for jurisdiction-constrained work.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub country: Option<String>,
+    /// Autonomous system number, for provider-diversity scoring.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub asn: Option<u32>,
+}
+
+impl ProviderAdvert {
+    /// Whether this advert replaces `other`. Both must come from the same
+    /// provider; the caller checks that, because an advert does not name
+    /// its own signer (the envelope does).
+    pub fn supersedes(&self, other: &ProviderAdvert) -> bool {
+        self.sequence > other.sequence
+    }
+
+    /// Whether this provider can run `workload`.
+    pub fn runs(&self, workload: &str) -> bool {
+        self.capabilities.workloads.iter().any(|w| w == workload)
+    }
+}
+
+impl Payload for ProviderAdvert {
+    const TYPE: &'static str = "c0mpute.provider.advert/v1";
+
+    fn expires_at(&self) -> Option<&Timestamp> {
+        Some(&self.expires_at)
+    }
+
+    fn validate(&self) -> Result<(), Error> {
+        if self.expires_at <= self.issued_at {
+            return Err(Error::Format(format!(
+                "advert expiresAt ({}) must be after issuedAt ({})",
+                self.expires_at, self.issued_at
+            )));
+        }
+        let lifetime = self.expires_at.unix_ms() - self.issued_at.unix_ms();
+        if lifetime > MAX_ADVERT_LIFETIME_MS {
+            return Err(Error::Format(format!(
+                "advert lifetime of {lifetime}ms exceeds the {MAX_ADVERT_LIFETIME_MS}ms maximum; \
+                 stale capacity is worse than a re-advert"
+            )));
+        }
+
+        let caps = &self.capabilities;
+        if caps.cpu.cores == 0 {
+            return Err(Error::Format(
+                "a provider must advertise at least 1 CPU core".into(),
+            ));
+        }
+        if caps.cpu.arch.is_empty() {
+            return Err(Error::Format("CPU architecture must not be empty".into()));
+        }
+        if caps.workloads.is_empty() {
+            return Err(Error::Format(
+                "a provider must advertise at least one workload; an advert with none is noise"
+                    .into(),
+            ));
+        }
+        for w in &caps.workloads {
+            validate_workload_type(w)?;
+        }
+        let mut sorted = caps.workloads.clone();
+        sorted.sort();
+        sorted.dedup();
+        if sorted.len() != caps.workloads.len() {
+            return Err(Error::Format("advertised workloads must be unique".into()));
+        }
+        for gpu in &caps.gpus {
+            if gpu.vendor.is_empty() {
+                return Err(Error::Format("GPU vendor must not be empty".into()));
+            }
+            if gpu.count == 0 {
+                return Err(Error::Format("GPU count must be at least 1".into()));
+            }
+        }
+
+        for rate in &self.pricing {
+            validate_workload_type(&rate.workload)?;
+            if rate.unit.is_empty() {
+                return Err(Error::Format("a rate must name a pricing unit".into()));
+            }
+            rate.price.validate()?;
+            if !caps.workloads.contains(&rate.workload) {
+                return Err(Error::Format(format!(
+                    "priced workload {:?} is not in the advertised workload list",
+                    rate.workload
+                )));
+            }
+        }
+
+        for cred in &self.trust.credentials {
+            if cred.type_id.is_empty() {
+                return Err(Error::Format("a credential must have a type".into()));
+            }
+        }
+        Ok(())
+    }
+}
+
+/// Check a workload namespace: lowercase, dot-separated, at least two
+/// segments (`transcode.ffmpeg`, not `transcode`).
+///
+/// The two-segment rule keeps the namespace from filling with bare verbs
+/// that different plugins would each read differently.
+pub fn validate_workload_type(s: &str) -> Result<(), Error> {
+    let bad = |why: &str| Error::Format(format!("workload type {s:?} {why}"));
+    if s.is_empty() {
+        return Err(bad("must not be empty"));
+    }
+    let segments: Vec<&str> = s.split('.').collect();
+    if segments.len() < 2 {
+        return Err(bad("must be namespaced, e.g. `transcode.ffmpeg`"));
+    }
+    for seg in segments {
+        if seg.is_empty() {
+            return Err(bad("has an empty segment"));
+        }
+        if !seg
+            .chars()
+            .all(|c| c.is_ascii_lowercase() || c.is_ascii_digit() || c == '-')
+        {
+            return Err(bad("must be lowercase alphanumeric with dashes"));
+        }
+    }
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::envelope::Envelope;
+    use crate::identity::SigningIdentity;
+
+    fn ts(s: &str) -> Timestamp {
+        Timestamp::parse(s).unwrap()
+    }
+
+    fn advert() -> ProviderAdvert {
+        ProviderAdvert {
+            sequence: 8472,
+            issued_at: ts("2026-09-06T23:50:00.000Z"),
+            expires_at: ts("2026-09-06T23:59:00.000Z"),
+            capabilities: ProviderCapabilities {
+                cpu: CpuSpec {
+                    arch: "x86_64".into(),
+                    cores: 32,
+                },
+                memory_gib: 128,
+                gpus: vec![GpuSpec {
+                    vendor: "nvidia".into(),
+                    family: Some("ada".into()),
+                    vram_gib: 24,
+                    features: vec!["cuda".into(), "nvenc".into()],
+                    count: 1,
+                }],
+                storage_gib: 1200,
+                bandwidth_mbps: 1000,
+                workloads: vec!["infernet.inference".into(), "transcode.ffmpeg".into()],
+            },
+            pricing: vec![Rate {
+                workload: "transcode.ffmpeg".into(),
+                unit: "video-minute".into(),
+                price: Money::new("0.004", "USD"),
+            }],
+            trust: ProviderTrust {
+                tier: TrustTier::Standard,
+                credentials: vec![],
+            },
+            disclosure: Some(Disclosure {
+                region: Some("us-west".into()),
+                country: None,
+                asn: Some(7922),
+            }),
+        }
+    }
+
+    #[test]
+    fn a_well_formed_advert_validates_and_seals() {
+        let a = advert();
+        a.validate().unwrap();
+        let env = Envelope::seal(&SigningIdentity::from_seed(&[1u8; 32]), a).unwrap();
+        let opened = env.open().unwrap();
+        assert!(opened.runs("transcode.ffmpeg"));
+        assert!(!opened.runs("oci.container"));
+    }
+
+    #[test]
+    fn advert_round_trips_through_canonical_json() {
+        let env = Envelope::seal(&SigningIdentity::from_seed(&[2u8; 32]), advert()).unwrap();
+        let json = env.to_canonical_json().unwrap();
+        assert!(
+            json.contains("\"expiresAt\""),
+            "wire form is camelCase: {json}"
+        );
+        let back: Envelope<ProviderAdvert> = Envelope::from_json(&json).unwrap();
+        back.open().unwrap();
+        assert_eq!(back.content_hash().unwrap(), env.content_hash().unwrap());
+    }
+
+    #[test]
+    fn a_long_lived_advert_is_rejected() {
+        let mut a = advert();
+        a.expires_at = ts("2026-09-07T23:59:00.000Z");
+        assert!(a.validate().is_err(), "a 24h advert should not be allowed");
+    }
+
+    #[test]
+    fn expiry_must_follow_issuance() {
+        let mut a = advert();
+        a.expires_at = a.issued_at.clone();
+        assert!(a.validate().is_err());
+    }
+
+    #[test]
+    fn an_advert_with_no_workloads_is_rejected() {
+        let mut a = advert();
+        a.capabilities.workloads.clear();
+        a.pricing.clear();
+        assert!(a.validate().is_err());
+    }
+
+    #[test]
+    fn duplicate_workloads_are_rejected() {
+        let mut a = advert();
+        a.capabilities.workloads = vec!["transcode.ffmpeg".into(), "transcode.ffmpeg".into()];
+        assert!(a.validate().is_err());
+    }
+
+    #[test]
+    fn pricing_a_workload_you_do_not_run_is_rejected() {
+        let mut a = advert();
+        a.pricing[0].workload = "whisper.transcribe".into();
+        assert!(a.validate().is_err());
+    }
+
+    #[test]
+    fn a_float_price_cannot_reach_the_wire() {
+        // The type system already forbids it; this guards the JSON path,
+        // where a hand-written or foreign-implementation advert could try.
+        let json = r#"{"workload":"transcode.ffmpeg","unit":"video-minute",
+                       "price":{"amount":0.004,"currency":"USD"}}"#;
+        assert!(serde_json::from_str::<Rate>(json).is_err());
+    }
+
+    #[test]
+    fn higher_sequence_supersedes() {
+        let old = advert();
+        let mut new = advert();
+        new.sequence = old.sequence + 1;
+        assert!(new.supersedes(&old));
+        assert!(!old.supersedes(&new));
+        assert!(!old.supersedes(&old), "equal sequence is not a replacement");
+    }
+
+    #[test]
+    fn an_expired_advert_fails_open_fresh_but_still_verifies() {
+        let env = Envelope::seal(&SigningIdentity::from_seed(&[3u8; 32]), advert()).unwrap();
+        let later = ts("2026-09-07T00:00:00.000Z");
+        assert!(matches!(
+            env.open_fresh(&later).unwrap_err(),
+            crate::Error::Expired { .. }
+        ));
+        env.open().unwrap();
+    }
+
+    #[test]
+    fn workload_namespaces_must_be_namespaced_and_lowercase() {
+        for ok in [
+            "transcode.ffmpeg",
+            "infernet.inference",
+            "oci.container",
+            "a.b.c",
+        ] {
+            validate_workload_type(ok).unwrap();
+        }
+        for bad in [
+            "",
+            "transcode",
+            "Transcode.FFmpeg",
+            "transcode.",
+            ".ffmpeg",
+            "a..b",
+            "a b.c",
+        ] {
+            assert!(
+                validate_workload_type(bad).is_err(),
+                "{bad:?} should be rejected"
+            );
+        }
+    }
+
+    #[test]
+    fn disclosure_is_optional() {
+        let mut a = advert();
+        a.disclosure = None;
+        a.validate().unwrap();
+        let env = Envelope::seal(&SigningIdentity::from_seed(&[4u8; 32]), a).unwrap();
+        let json = env.to_canonical_json().unwrap();
+        assert!(
+            !json.contains("disclosure"),
+            "an undisclosed field should not appear on the wire at all: {json}"
+        );
+    }
+}

--- a/node/crates/c0mpute-envelope/src/canonical.rs
+++ b/node/crates/c0mpute-envelope/src/canonical.rs
@@ -1,0 +1,224 @@
+//! Canonical JSON — the exact bytes a c0mpute signature covers.
+//!
+//! Two implementations in two languages must produce byte-identical output
+//! for the same logical value, or every hash and signature on the network
+//! becomes implementation-specific. RFC 8785 (JCS) is the reference, with
+//! two deliberate restrictions that remove its hardest corners:
+//!
+//! 1. **No floating-point numbers.** JCS canonicalizes doubles via the
+//!    ECMAScript `Number::toString` algorithm, which is genuinely hard to
+//!    reimplement correctly. c0mpute forbids floats in signed payloads
+//!    outright: money is a decimal *string* (`"0.042"`), durations and
+//!    sizes are integers. [`canonicalize`] rejects a float rather than
+//!    guessing.
+//! 2. **ASCII object keys.** JCS sorts keys by UTF-16 code unit, which
+//!    differs from UTF-8 byte order above U+FFFF. Restricting keys to
+//!    ASCII makes the two orderings identical, so an implementation can
+//!    sort raw bytes and still be correct.
+//!
+//! Both restrictions are checked, not assumed. A payload that violates one
+//! fails to canonicalize instead of signing something another node will
+//! hash differently.
+
+use serde::Serialize;
+use serde_json::Value;
+
+use crate::Error;
+
+/// The largest integer magnitude that survives a round trip through an
+/// IEEE-754 double, i.e. through any JSON parser backed by JavaScript
+/// numbers. Signed payloads stay inside it so a browser client and a Rust
+/// node agree on the value.
+pub const MAX_SAFE_INT: u64 = (1u64 << 53) - 1;
+
+/// Serialize `value` to canonical JSON bytes.
+///
+/// Returns [`Error::NonCanonical`] if the value contains a float, an
+/// out-of-range integer, or a non-ASCII object key.
+pub fn canonicalize<T: Serialize>(value: &T) -> Result<Vec<u8>, Error> {
+    let json = serde_json::to_value(value)?;
+    let mut out = Vec::new();
+    write_value(&json, &mut out)?;
+    Ok(out)
+}
+
+/// Convenience wrapper around [`canonicalize`] for callers that want a
+/// `String` (canonical JSON is always valid UTF-8).
+pub fn canonicalize_to_string<T: Serialize>(value: &T) -> Result<String, Error> {
+    let bytes = canonicalize(value)?;
+    // write_value only ever emits UTF-8.
+    Ok(String::from_utf8(bytes).expect("canonical JSON is UTF-8"))
+}
+
+fn write_value(v: &Value, out: &mut Vec<u8>) -> Result<(), Error> {
+    match v {
+        Value::Null => out.extend_from_slice(b"null"),
+        Value::Bool(true) => out.extend_from_slice(b"true"),
+        Value::Bool(false) => out.extend_from_slice(b"false"),
+        Value::Number(n) => write_number(n, out)?,
+        Value::String(s) => write_string(s, out),
+        Value::Array(items) => {
+            out.push(b'[');
+            for (i, item) in items.iter().enumerate() {
+                if i > 0 {
+                    out.push(b',');
+                }
+                write_value(item, out)?;
+            }
+            out.push(b']');
+        }
+        Value::Object(map) => {
+            // Sort explicitly rather than relying on serde_json's map type:
+            // the `preserve_order` feature can be switched on anywhere in the
+            // dependency graph and would silently give us insertion order.
+            let mut keys: Vec<&String> = map.keys().collect();
+            keys.sort_unstable_by(|a, b| a.as_bytes().cmp(b.as_bytes()));
+            out.push(b'{');
+            for (i, key) in keys.iter().enumerate() {
+                if !key.is_ascii() {
+                    return Err(Error::NonCanonical(format!(
+                        "object key {key:?} is not ASCII; canonical JSON keys must be ASCII"
+                    )));
+                }
+                if i > 0 {
+                    out.push(b',');
+                }
+                write_string(key, out);
+                out.push(b':');
+                write_value(&map[*key], out)?;
+            }
+            out.push(b'}');
+        }
+    }
+    Ok(())
+}
+
+fn write_number(n: &serde_json::Number, out: &mut Vec<u8>) -> Result<(), Error> {
+    if let Some(u) = n.as_u64() {
+        if u > MAX_SAFE_INT {
+            return Err(Error::NonCanonical(format!(
+                "integer {u} exceeds the safe-integer range; encode large values as strings"
+            )));
+        }
+        out.extend_from_slice(u.to_string().as_bytes());
+        return Ok(());
+    }
+    if let Some(i) = n.as_i64() {
+        if i.unsigned_abs() > MAX_SAFE_INT {
+            return Err(Error::NonCanonical(format!(
+                "integer {i} exceeds the safe-integer range; encode large values as strings"
+            )));
+        }
+        out.extend_from_slice(i.to_string().as_bytes());
+        return Ok(());
+    }
+    Err(Error::NonCanonical(format!(
+        "floating-point number {n} is not allowed in a signed payload; \
+         use a decimal string for money and an integer for counts"
+    )))
+}
+
+fn write_string(s: &str, out: &mut Vec<u8>) {
+    out.push(b'"');
+    for c in s.chars() {
+        match c {
+            '"' => out.extend_from_slice(b"\\\""),
+            '\\' => out.extend_from_slice(b"\\\\"),
+            '\u{08}' => out.extend_from_slice(b"\\b"),
+            '\u{0c}' => out.extend_from_slice(b"\\f"),
+            '\n' => out.extend_from_slice(b"\\n"),
+            '\r' => out.extend_from_slice(b"\\r"),
+            '\t' => out.extend_from_slice(b"\\t"),
+            c if (c as u32) < 0x20 => {
+                out.extend_from_slice(format!("\\u{:04x}", c as u32).as_bytes());
+            }
+            c => {
+                let mut buf = [0u8; 4];
+                out.extend_from_slice(c.encode_utf8(&mut buf).as_bytes());
+            }
+        }
+    }
+    out.push(b'"');
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json::json;
+
+    #[test]
+    fn object_keys_are_sorted_regardless_of_input_order() {
+        let a = canonicalize_to_string(&json!({"b": 1, "a": 2, "c": 3})).unwrap();
+        let b = canonicalize_to_string(&json!({"c": 3, "a": 2, "b": 1})).unwrap();
+        assert_eq!(a, b);
+        assert_eq!(a, r#"{"a":2,"b":1,"c":3}"#);
+    }
+
+    #[test]
+    fn nested_objects_are_sorted_too() {
+        let s = canonicalize_to_string(&json!({
+            "z": {"second": 2, "first": 1},
+            "a": [{"y": 1, "x": 2}]
+        }))
+        .unwrap();
+        assert_eq!(s, r#"{"a":[{"x":2,"y":1}],"z":{"first":1,"second":2}}"#);
+    }
+
+    #[test]
+    fn array_order_is_preserved() {
+        let s = canonicalize_to_string(&json!([3, 1, 2])).unwrap();
+        assert_eq!(s, "[3,1,2]");
+    }
+
+    #[test]
+    fn no_insignificant_whitespace() {
+        let s = canonicalize_to_string(&json!({"a": [1, 2], "b": {"c": null}})).unwrap();
+        assert!(!s.contains(' '));
+        assert_eq!(s, r#"{"a":[1,2],"b":{"c":null}}"#);
+    }
+
+    #[test]
+    fn floats_are_rejected() {
+        let err = canonicalize(&json!({"price": 0.042})).unwrap_err();
+        assert!(matches!(err, Error::NonCanonical(_)), "got {err:?}");
+    }
+
+    #[test]
+    fn float_rejection_survives_nesting() {
+        let err = canonicalize(&json!({"a": {"b": [1, 2.5]}})).unwrap_err();
+        assert!(matches!(err, Error::NonCanonical(_)));
+    }
+
+    #[test]
+    fn unsafe_integers_are_rejected() {
+        let err = canonicalize(&json!({"n": MAX_SAFE_INT + 1})).unwrap_err();
+        assert!(matches!(err, Error::NonCanonical(_)));
+        // The boundary itself is fine.
+        canonicalize(&json!({"n": MAX_SAFE_INT})).unwrap();
+    }
+
+    #[test]
+    fn non_ascii_keys_are_rejected() {
+        let err = canonicalize(&json!({"café": 1})).unwrap_err();
+        assert!(matches!(err, Error::NonCanonical(_)));
+    }
+
+    #[test]
+    fn non_ascii_string_values_are_allowed_verbatim() {
+        // Values may be any UTF-8; only keys are restricted.
+        let s = canonicalize_to_string(&json!({"note": "café ☕"})).unwrap();
+        assert_eq!(s, "{\"note\":\"café ☕\"}");
+    }
+
+    #[test]
+    fn control_characters_use_lowercase_hex_escapes() {
+        let s = canonicalize_to_string(&json!({"a": "\u{1}\u{1f}"})).unwrap();
+        assert_eq!(s, "{\"a\":\"\\u0001\\u001f\"}");
+    }
+
+    #[test]
+    fn short_escapes_are_preferred_over_hex() {
+        let s = canonicalize_to_string(&json!({"a": "\n\t\r\"\\"})).unwrap();
+        assert_eq!(s, r#"{"a":"\n\t\r\"\\"}"#);
+    }
+}

--- a/node/crates/c0mpute-envelope/src/envelope.rs
+++ b/node/crates/c0mpute-envelope/src/envelope.rs
@@ -1,0 +1,369 @@
+//! The signed envelope every c0mpute protocol message travels in.
+//!
+//! ```json
+//! {
+//!   "v": 1,
+//!   "type": "c0mpute.provider.advert/v1",
+//!   "signer": "did:c0mpute:z6Mk…",
+//!   "payload": { … },
+//!   "sig": "z3yf…"
+//! }
+//! ```
+//!
+//! Why an envelope at all, when gossipsub already signs each message with
+//! the publisher's key? Because a transport signature dies at the first
+//! hop. An advert relayed by an indexer, a receipt stored in a buyer's
+//! local log, an offer forwarded by a gateway, a job replayed from disk
+//! after a restart — none of those carry the gossipsub signature, and all
+//! of them need to be verifiable by someone who was not on the wire when
+//! the message was published. The v1 types in `c0mpute-net::topics`
+//! leaned on transport authenticity; that is what made reputation
+//! non-portable and required a database to be believed.
+//!
+//! Signatures are domain-separated by [`DOMAIN`] and by the payload type,
+//! so a signature harvested from one message type can never be replayed as
+//! another.
+
+use serde::{Serialize, de::DeserializeOwned};
+
+use crate::Error;
+use crate::canonical::canonicalize;
+use crate::identity::{Did, EnvelopeSignature, SigningIdentity};
+use crate::types::{ContentHash, Timestamp};
+
+/// Envelope format version. Bumped only for a breaking change to the
+/// envelope's own shape, never for a payload change (payload types carry
+/// their own version in [`Payload::TYPE`]).
+pub const ENVELOPE_VERSION: u32 = 1;
+
+/// Domain-separation tag prefixed to every signing input.
+pub const DOMAIN: &[u8] = b"c0mpute-envelope/v1\n";
+
+/// A payload that can travel in a signed envelope.
+pub trait Payload: Serialize + DeserializeOwned {
+    /// Stable type identifier, e.g. `c0mpute.job/v2`. Part of the signing
+    /// input, so it is not forgeable after the fact.
+    const TYPE: &'static str;
+
+    /// Structural checks that must hold before a payload is signed and
+    /// after it is verified. A malformed payload should never reach
+    /// application code with a valid signature attached.
+    fn validate(&self) -> Result<(), Error>;
+
+    /// When this payload stops being usable, if it says so itself.
+    /// Adverts and offers expire; receipts are permanent records and do
+    /// not.
+    fn expires_at(&self) -> Option<&Timestamp> {
+        None
+    }
+}
+
+/// A payload plus the signature of the peer that vouched for it.
+#[derive(Clone, Debug, Serialize, serde::Deserialize)]
+pub struct Envelope<T> {
+    /// Envelope format version.
+    pub v: u32,
+    /// Payload type identifier.
+    #[serde(rename = "type")]
+    pub type_id: String,
+    /// The identity that signed the payload.
+    pub signer: Did,
+    /// The payload itself.
+    pub payload: T,
+    /// Detached signature over the domain-separated canonical bytes.
+    pub sig: EnvelopeSignature,
+}
+
+/// The exact fields a signature covers, in the order serde emits them.
+/// Canonicalization sorts keys, so field order here is irrelevant to the
+/// output — this struct exists only to avoid cloning the payload.
+#[derive(Serialize)]
+struct SigningView<'a, T> {
+    v: u32,
+    #[serde(rename = "type")]
+    type_id: &'a str,
+    signer: &'a Did,
+    payload: &'a T,
+}
+
+/// Build the bytes a signature is computed over.
+fn signing_input<T: Serialize>(type_id: &str, signer: &Did, payload: &T) -> Result<Vec<u8>, Error> {
+    let view = SigningView {
+        v: ENVELOPE_VERSION,
+        type_id,
+        signer,
+        payload,
+    };
+    let canonical = canonicalize(&view)?;
+    let mut input = Vec::with_capacity(DOMAIN.len() + type_id.len() + 1 + canonical.len());
+    input.extend_from_slice(DOMAIN);
+    input.extend_from_slice(type_id.as_bytes());
+    input.push(b'\n');
+    input.extend_from_slice(&canonical);
+    Ok(input)
+}
+
+impl<T: Payload> Envelope<T> {
+    /// Validate, then sign, a payload.
+    ///
+    /// Validation happens *before* signing on purpose: a signature is a
+    /// claim that the signer stands behind the contents, and there is no
+    /// reason to stand behind a payload we already know is malformed.
+    pub fn seal(identity: &SigningIdentity, payload: T) -> Result<Self, Error> {
+        payload.validate()?;
+        let signer = identity.did().clone();
+        let input = signing_input(T::TYPE, &signer, &payload)?;
+        let sig = identity.sign(&input);
+        Ok(Self {
+            v: ENVELOPE_VERSION,
+            type_id: T::TYPE.to_string(),
+            signer,
+            payload,
+            sig,
+        })
+    }
+
+    /// Verify the envelope and hand back the payload it carries.
+    ///
+    /// Checks, in order: envelope version, payload type, signature, then
+    /// payload structure. Nothing else in the codebase should read
+    /// `envelope.payload` directly — going through here is what makes
+    /// "we saw this message" and "this peer signed this message" the same
+    /// statement.
+    pub fn open(&self) -> Result<&T, Error> {
+        if self.v != ENVELOPE_VERSION {
+            return Err(Error::Format(format!(
+                "unsupported envelope version {}; this node speaks v{ENVELOPE_VERSION}",
+                self.v
+            )));
+        }
+        if self.type_id != T::TYPE {
+            return Err(Error::TypeMismatch {
+                expected: T::TYPE,
+                found: self.type_id.clone(),
+            });
+        }
+        let input = signing_input(&self.type_id, &self.signer, &self.payload)?;
+        self.signer.verify(&input, &self.sig)?;
+        self.payload.validate()?;
+        Ok(&self.payload)
+    }
+
+    /// [`Envelope::open`] plus a freshness check against `now`.
+    ///
+    /// Expired adverts and offers are the normal case on a churning
+    /// network, not an attack — a provider that went offline leaves its
+    /// last advert in every peer's cache. Rejecting them on read is what
+    /// keeps a stale cache from looking like live capacity.
+    pub fn open_fresh(&self, now: &Timestamp) -> Result<&T, Error> {
+        let payload = self.open()?;
+        if let Some(expiry) = payload.expires_at() {
+            if expiry.is_expired_at(now) {
+                return Err(Error::Expired {
+                    expired_at: expiry.to_string(),
+                    now: now.to_string(),
+                });
+            }
+        }
+        Ok(payload)
+    }
+
+    /// Stable content hash of the sealed envelope.
+    ///
+    /// Two nodes that received the same envelope compute the same hash, so
+    /// this is the identifier to cite an advert, offer, or receipt by
+    /// without re-sending it.
+    pub fn content_hash(&self) -> Result<ContentHash, Error> {
+        Ok(ContentHash::of(&canonicalize(self)?))
+    }
+
+    /// Serialize to canonical JSON — the form to store or transmit, so a
+    /// re-read produces the same hash.
+    pub fn to_canonical_json(&self) -> Result<String, Error> {
+        crate::canonical::canonicalize_to_string(self)
+    }
+
+    /// Parse an envelope from JSON. Does **not** verify; call
+    /// [`Envelope::open`] next.
+    pub fn from_json(s: &str) -> Result<Self, Error> {
+        Ok(serde_json::from_str(s)?)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde::Deserialize;
+
+    #[derive(Clone, Debug, Serialize, Deserialize, PartialEq)]
+    struct Ping {
+        note: String,
+        #[serde(skip_serializing_if = "Option::is_none")]
+        expires_at: Option<Timestamp>,
+    }
+
+    impl Payload for Ping {
+        const TYPE: &'static str = "c0mpute.test.ping/v1";
+        fn validate(&self) -> Result<(), Error> {
+            if self.note.is_empty() {
+                return Err(Error::Format("note must not be empty".into()));
+            }
+            Ok(())
+        }
+        fn expires_at(&self) -> Option<&Timestamp> {
+            self.expires_at.as_ref()
+        }
+    }
+
+    #[derive(Clone, Debug, Serialize, Deserialize, PartialEq)]
+    struct Pong {
+        note: String,
+    }
+
+    impl Payload for Pong {
+        // Same shape as Ping, different type id — this is what domain
+        // separation has to defeat.
+        const TYPE: &'static str = "c0mpute.test.pong/v1";
+        fn validate(&self) -> Result<(), Error> {
+            Ok(())
+        }
+    }
+
+    fn identity(byte: u8) -> SigningIdentity {
+        SigningIdentity::from_seed(&[byte; 32])
+    }
+
+    fn ping(note: &str) -> Ping {
+        Ping {
+            note: note.into(),
+            expires_at: None,
+        }
+    }
+
+    #[test]
+    fn seal_then_open_returns_the_payload() {
+        let id = identity(1);
+        let env = Envelope::seal(&id, ping("hello")).unwrap();
+        assert_eq!(env.open().unwrap().note, "hello");
+        assert_eq!(env.signer.as_str(), id.did().as_str());
+        assert_eq!(env.type_id, Ping::TYPE);
+    }
+
+    #[test]
+    fn envelope_survives_a_json_round_trip() {
+        let env = Envelope::seal(&identity(2), ping("durable")).unwrap();
+        let json = env.to_canonical_json().unwrap();
+        let parsed: Envelope<Ping> = Envelope::from_json(&json).unwrap();
+        parsed.open().unwrap();
+        assert_eq!(parsed.content_hash().unwrap(), env.content_hash().unwrap());
+    }
+
+    #[test]
+    fn a_tampered_payload_fails_verification() {
+        let mut env = Envelope::seal(&identity(3), ping("original")).unwrap();
+        env.payload.note = "tampered".into();
+        assert!(matches!(env.open().unwrap_err(), Error::BadSignature));
+    }
+
+    #[test]
+    fn a_swapped_signer_fails_verification() {
+        let mut env = Envelope::seal(&identity(4), ping("mine")).unwrap();
+        env.signer = identity(5).did().clone();
+        assert!(matches!(env.open().unwrap_err(), Error::BadSignature));
+    }
+
+    #[test]
+    fn a_signature_cannot_be_replayed_across_payload_types() {
+        // Identical bytes, different type id: the domain separation in the
+        // signing input has to make the signature useless here.
+        let id = identity(6);
+        let signed_ping = Envelope::seal(&id, ping("same")).unwrap();
+        let forged = Envelope::<Pong> {
+            v: signed_ping.v,
+            type_id: Pong::TYPE.to_string(),
+            signer: signed_ping.signer.clone(),
+            payload: Pong {
+                note: "same".into(),
+            },
+            sig: signed_ping.sig.clone(),
+        };
+        assert!(matches!(forged.open().unwrap_err(), Error::BadSignature));
+    }
+
+    #[test]
+    fn opening_as_the_wrong_type_is_reported_as_a_mismatch() {
+        let env = Envelope::seal(&identity(7), ping("typed")).unwrap();
+        let json = env.to_canonical_json().unwrap();
+        // Deserializing a Ping body into an Envelope<Pong> works
+        // structurally; the type id is what catches it.
+        let as_pong: Envelope<Pong> = serde_json::from_str(&json).unwrap();
+        assert!(matches!(
+            as_pong.open().unwrap_err(),
+            Error::TypeMismatch {
+                expected: "c0mpute.test.pong/v1",
+                ..
+            }
+        ));
+    }
+
+    #[test]
+    fn an_unknown_envelope_version_is_rejected() {
+        let mut env = Envelope::seal(&identity(8), ping("v")).unwrap();
+        env.v = 99;
+        assert!(matches!(env.open().unwrap_err(), Error::Format(_)));
+    }
+
+    #[test]
+    fn an_invalid_payload_cannot_be_sealed() {
+        let err = Envelope::seal(&identity(9), ping("")).unwrap_err();
+        assert!(matches!(err, Error::Format(_)));
+    }
+
+    #[test]
+    fn expiry_is_enforced_only_by_open_fresh() {
+        let id = identity(10);
+        let expires = Timestamp::parse("2026-09-06T16:00:00.000Z").unwrap();
+        let env = Envelope::seal(
+            &id,
+            Ping {
+                note: "short-lived".into(),
+                expires_at: Some(expires.clone()),
+            },
+        )
+        .unwrap();
+
+        let before = Timestamp::parse("2026-09-06T15:59:59.999Z").unwrap();
+        let after = Timestamp::parse("2026-09-06T16:00:00.001Z").unwrap();
+
+        env.open_fresh(&before).unwrap();
+        assert!(matches!(
+            env.open_fresh(&after).unwrap_err(),
+            Error::Expired { .. }
+        ));
+        // `open` still verifies a stale-but-authentic message: an expired
+        // advert is history, not a forgery.
+        env.open().unwrap();
+    }
+
+    #[test]
+    fn content_hash_is_stable_across_key_ordering() {
+        let env = Envelope::seal(&identity(11), ping("stable")).unwrap();
+        let hash = env.content_hash().unwrap();
+
+        // Re-serialize with deliberately shuffled keys, reparse, rehash.
+        let value: serde_json::Value =
+            serde_json::from_str(&env.to_canonical_json().unwrap()).unwrap();
+        let shuffled = serde_json::to_string(&value).unwrap();
+        let reparsed: Envelope<Ping> = Envelope::from_json(&shuffled).unwrap();
+        assert_eq!(reparsed.content_hash().unwrap(), hash);
+    }
+
+    #[test]
+    fn signatures_are_deterministic_for_the_same_input() {
+        // ed25519 is deterministic; two seals of the same payload by the
+        // same key must agree, or the content hash is not a stable id.
+        let a = Envelope::seal(&identity(12), ping("det")).unwrap();
+        let b = Envelope::seal(&identity(12), ping("det")).unwrap();
+        assert_eq!(a.content_hash().unwrap(), b.content_hash().unwrap());
+    }
+}

--- a/node/crates/c0mpute-envelope/src/identity.rs
+++ b/node/crates/c0mpute-envelope/src/identity.rs
@@ -273,7 +273,12 @@ mod tests {
 
     #[test]
     fn parse_rejects_a_foreign_method() {
-        assert!(Did::parse("did:key:z6MkhaXgBZDvotDkL5257faiztiGiC2QtKLGpbnnEGta2doK").is_err());
+        // The example ed25519 identifier from the did:key spec. It is a
+        // *public* key — being public is the entire point of a DID — but
+        // it is 44 characters of base58 and gitleaks' generic-api-key rule
+        // scores it on entropy alone, so it needs the allow directive.
+        let did_key = "did:key:z6MkhaXgBZDvotDkL5257faiztiGiC2QtKLGpbnnEGta2doK"; // gitleaks:allow
+        assert!(Did::parse(did_key).is_err());
     }
 
     #[test]

--- a/node/crates/c0mpute-envelope/src/identity.rs
+++ b/node/crates/c0mpute-envelope/src/identity.rs
@@ -1,0 +1,301 @@
+//! Native c0mpute network identity.
+//!
+//! A c0mpute peer's protocol identity is an ed25519 keypair rendered as a
+//! DID:
+//!
+//! ```text
+//! did:c0mpute:z6MkhaXgBZDvotDkL5257faiztiGiC2QtKLGpbnnEGta2doK
+//!             ^ multibase base58btc of (0xed 0x01 || 32-byte public key)
+//! ```
+//!
+//! The encoding after `z` is byte-identical to `did:key` for ed25519, so
+//! any DID tooling that already resolves `did:key:z6Mk…` resolves a
+//! c0mpute identity by swapping the method name. That is deliberate:
+//! the network needs a stable, self-certifying identifier, not a new
+//! registry.
+//!
+//! **Identity is not payment.** A node generates this locally, offline,
+//! with no account anywhere. CoinPay wallets, KYC attestations, hardware
+//! attestations, and organization membership all attach to this key as
+//! separate credentials (see `docs/protocol/identity.md`); none of them
+//! are required to join the network, advertise capacity, or be paid by an
+//! adapter that does not use them.
+//!
+//! The bytes are the same ed25519 key libp2p already persists at
+//! `<config_dir>/identity.key`, so a node has exactly one identity across
+//! transport and protocol layers. This crate stays free of any libp2p
+//! dependency — [`SigningIdentity::from_seed`] takes the raw 32 bytes and
+//! the transport layer does the bridging.
+
+use ed25519_dalek::{Signature, Signer, SigningKey, Verifier, VerifyingKey};
+use serde::{Deserialize, Serialize};
+
+use crate::Error;
+
+/// DID method prefix for a c0mpute network identity.
+pub const DID_PREFIX: &str = "did:c0mpute:";
+
+/// Multicodec varint for an ed25519 public key.
+const MULTICODEC_ED25519_PUB: [u8; 2] = [0xed, 0x01];
+
+/// A peer's public identity: `did:c0mpute:z…`.
+///
+/// Self-certifying — the DID *is* the public key, so verifying a signature
+/// needs no lookup, no registry, and no network round trip.
+#[derive(Clone, PartialEq, Eq, Hash)]
+pub struct Did {
+    key: VerifyingKey,
+    text: String,
+}
+
+impl Did {
+    /// Build a DID from a raw 32-byte ed25519 public key.
+    pub fn from_public_key_bytes(bytes: &[u8; 32]) -> Result<Self, Error> {
+        let key = VerifyingKey::from_bytes(bytes)
+            .map_err(|e| Error::Identity(format!("not a valid ed25519 public key: {e}")))?;
+        Ok(Self::from_verifying_key(key))
+    }
+
+    fn from_verifying_key(key: VerifyingKey) -> Self {
+        let mut multi = Vec::with_capacity(34);
+        multi.extend_from_slice(&MULTICODEC_ED25519_PUB);
+        multi.extend_from_slice(key.as_bytes());
+        let text = format!("{DID_PREFIX}z{}", bs58::encode(&multi).into_string());
+        Self { key, text }
+    }
+
+    /// Parse `did:c0mpute:z…` back into a verifiable public key.
+    pub fn parse(s: &str) -> Result<Self, Error> {
+        let body = s
+            .strip_prefix(DID_PREFIX)
+            .ok_or_else(|| Error::Identity(format!("DID must start with {DID_PREFIX:?}")))?;
+        let b58 = body.strip_prefix('z').ok_or_else(|| {
+            Error::Identity("DID body must use multibase base58btc (leading 'z')".into())
+        })?;
+        let multi = bs58::decode(b58)
+            .into_vec()
+            .map_err(|e| Error::Identity(format!("DID body is not valid base58btc: {e}")))?;
+        let Some((codec, key_bytes)) = multi.split_at_checked(2) else {
+            return Err(Error::Identity("DID body is too short".into()));
+        };
+        if codec != MULTICODEC_ED25519_PUB {
+            return Err(Error::Identity(format!(
+                "unsupported key type {codec:02x?}; c0mpute identities are ed25519"
+            )));
+        }
+        let arr: [u8; 32] = key_bytes
+            .try_into()
+            .map_err(|_| Error::Identity("ed25519 public key must be 32 bytes".into()))?;
+        Self::from_public_key_bytes(&arr)
+    }
+
+    /// The DID string, e.g. `did:c0mpute:z6Mk…`.
+    pub fn as_str(&self) -> &str {
+        &self.text
+    }
+
+    /// Raw 32-byte ed25519 public key.
+    pub fn public_key_bytes(&self) -> [u8; 32] {
+        self.key.to_bytes()
+    }
+
+    /// Verify a detached signature over `msg`.
+    pub fn verify(&self, msg: &[u8], sig: &EnvelopeSignature) -> Result<(), Error> {
+        self.key
+            .verify(msg, &sig.0)
+            .map_err(|_| Error::BadSignature)
+    }
+}
+
+impl std::fmt::Display for Did {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.write_str(&self.text)
+    }
+}
+
+impl std::fmt::Debug for Did {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "Did({})", self.text)
+    }
+}
+
+impl Serialize for Did {
+    fn serialize<S: serde::Serializer>(&self, s: S) -> Result<S::Ok, S::Error> {
+        s.serialize_str(&self.text)
+    }
+}
+
+impl<'de> Deserialize<'de> for Did {
+    fn deserialize<D: serde::Deserializer<'de>>(d: D) -> Result<Self, D::Error> {
+        let s = String::deserialize(d)?;
+        Did::parse(&s).map_err(serde::de::Error::custom)
+    }
+}
+
+/// A node's private half: the key that signs envelopes.
+///
+/// Never serialized. Loaded from the same on-disk key the transport uses.
+pub struct SigningIdentity {
+    key: SigningKey,
+    did: Did,
+}
+
+impl SigningIdentity {
+    /// Build from a raw 32-byte ed25519 secret key (an "expanded seed" in
+    /// RFC 8032 terms). This is the same 32 bytes libp2p's
+    /// `Keypair::try_into_ed25519()?.secret()` yields, so transport and
+    /// protocol identity stay one key.
+    pub fn from_seed(seed: &[u8; 32]) -> Self {
+        let key = SigningKey::from_bytes(seed);
+        let did = Did::from_verifying_key(key.verifying_key());
+        Self { key, did }
+    }
+
+    /// This identity's public DID.
+    pub fn did(&self) -> &Did {
+        &self.did
+    }
+
+    /// Sign arbitrary bytes. Callers should prefer the envelope helpers,
+    /// which apply domain separation before reaching this.
+    pub fn sign(&self, msg: &[u8]) -> EnvelopeSignature {
+        EnvelopeSignature(self.key.sign(msg))
+    }
+}
+
+impl std::fmt::Debug for SigningIdentity {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        // Never render key material, not even by accident in a log line.
+        write!(f, "SigningIdentity({})", self.did)
+    }
+}
+
+/// A detached ed25519 signature, wire-encoded as multibase base58btc
+/// (`z…`) to match the DID encoding.
+#[derive(Clone, PartialEq, Eq)]
+pub struct EnvelopeSignature(Signature);
+
+impl EnvelopeSignature {
+    pub fn to_wire(&self) -> String {
+        format!("z{}", bs58::encode(self.0.to_bytes()).into_string())
+    }
+
+    pub fn parse(s: &str) -> Result<Self, Error> {
+        let b58 = s.strip_prefix('z').ok_or_else(|| {
+            Error::Identity("signature must use multibase base58btc (leading 'z')".into())
+        })?;
+        let bytes = bs58::decode(b58)
+            .into_vec()
+            .map_err(|e| Error::Identity(format!("signature is not valid base58btc: {e}")))?;
+        let arr: [u8; 64] = bytes
+            .try_into()
+            .map_err(|_| Error::Identity("ed25519 signature must be 64 bytes".into()))?;
+        Ok(Self(Signature::from_bytes(&arr)))
+    }
+}
+
+impl std::fmt::Debug for EnvelopeSignature {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "EnvelopeSignature({})", self.to_wire())
+    }
+}
+
+impl Serialize for EnvelopeSignature {
+    fn serialize<S: serde::Serializer>(&self, s: S) -> Result<S::Ok, S::Error> {
+        s.serialize_str(&self.to_wire())
+    }
+}
+
+impl<'de> Deserialize<'de> for EnvelopeSignature {
+    fn deserialize<D: serde::Deserializer<'de>>(d: D) -> Result<Self, D::Error> {
+        let s = String::deserialize(d)?;
+        EnvelopeSignature::parse(&s).map_err(serde::de::Error::custom)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// Fixed seeds keep the vectors deterministic — another implementation
+    /// can check itself against the DIDs these produce.
+    pub(crate) fn test_identity(byte: u8) -> SigningIdentity {
+        SigningIdentity::from_seed(&[byte; 32])
+    }
+
+    #[test]
+    fn did_uses_the_did_key_ed25519_encoding() {
+        let id = test_identity(1);
+        let did = id.did().as_str();
+        assert!(did.starts_with("did:c0mpute:z6Mk"), "got {did}");
+    }
+
+    #[test]
+    fn did_round_trips_through_its_string_form() {
+        let id = test_identity(7);
+        let parsed = Did::parse(id.did().as_str()).unwrap();
+        assert_eq!(&parsed, id.did());
+        assert_eq!(parsed.public_key_bytes(), id.did().public_key_bytes());
+    }
+
+    #[test]
+    fn distinct_seeds_give_distinct_dids() {
+        assert_ne!(test_identity(1).did(), test_identity(2).did());
+    }
+
+    #[test]
+    fn signature_round_trips_and_verifies() {
+        let id = test_identity(3);
+        let sig = id.sign(b"hello c0mpute");
+        let wire = sig.to_wire();
+        let parsed = EnvelopeSignature::parse(&wire).unwrap();
+        id.did().verify(b"hello c0mpute", &parsed).unwrap();
+    }
+
+    #[test]
+    fn signature_does_not_verify_for_other_bytes() {
+        let id = test_identity(3);
+        let sig = id.sign(b"hello c0mpute");
+        let err = id.did().verify(b"hello c0mputer", &sig).unwrap_err();
+        assert!(matches!(err, Error::BadSignature));
+    }
+
+    #[test]
+    fn signature_does_not_verify_under_another_did() {
+        let a = test_identity(4);
+        let b = test_identity(5);
+        let sig = a.sign(b"payload");
+        assert!(matches!(
+            b.did().verify(b"payload", &sig).unwrap_err(),
+            Error::BadSignature
+        ));
+    }
+
+    #[test]
+    fn parse_rejects_a_foreign_method() {
+        assert!(Did::parse("did:key:z6MkhaXgBZDvotDkL5257faiztiGiC2QtKLGpbnnEGta2doK").is_err());
+    }
+
+    #[test]
+    fn parse_rejects_a_non_ed25519_multicodec() {
+        // 0xe7 0x01 is secp256k1-pub.
+        let mut multi = vec![0xe7, 0x01];
+        multi.extend_from_slice(&[9u8; 32]);
+        let did = format!("{DID_PREFIX}z{}", bs58::encode(&multi).into_string());
+        assert!(Did::parse(&did).is_err());
+    }
+
+    #[test]
+    fn parse_rejects_a_truncated_body() {
+        let did = format!("{DID_PREFIX}z{}", bs58::encode([0xed]).into_string());
+        assert!(Did::parse(&did).is_err());
+    }
+
+    #[test]
+    fn debug_never_prints_key_material() {
+        let id = test_identity(6);
+        let rendered = format!("{id:?}");
+        assert!(rendered.contains(id.did().as_str()));
+        assert!(!rendered.contains("SigningKey"));
+    }
+}

--- a/node/crates/c0mpute-envelope/src/job.rs
+++ b/node/crates/c0mpute-envelope/src/job.rs
@@ -1,0 +1,546 @@
+//! `c0mpute.job/v2` — a buyer describes work rather than a machine.
+//!
+//! The manifest is the network's central portable abstraction. It says
+//! what to run, what the provider must have, how much the buyer will pay,
+//! how the result gets checked, and who settles it — and it says all of
+//! that without naming a provider, a scheduler, or a host. That absence is
+//! the point: the same manifest is schedulable by a local CLI, by a
+//! managed gateway the buyer delegated to, or by a private organization
+//! scheduler, and none of them is privileged over the others.
+//!
+//! ## Job identity
+//!
+//! A job's id is the content hash of its canonical manifest —
+//! [`JobManifest::id`]. The v2 direction sketches an `id` field *inside*
+//! the manifest, which forces every implementation to agree on which
+//! fields to strip before hashing. Deriving the id from the whole manifest
+//! removes that step and the class of bugs that lives in it: two nodes
+//! that hold the same manifest cannot disagree about what to call it.
+
+use serde::{Deserialize, Serialize};
+
+use crate::Error;
+use crate::advert::validate_workload_type;
+use crate::canonical::canonicalize;
+use crate::envelope::Payload;
+use crate::identity::Did;
+use crate::types::{ContentHash, Money, SettlementAdapter, Timestamp, TrustTier, ValidationPolicy};
+
+/// Ceiling on `execution.retry`. Retries multiply spend against the same
+/// escrow, so the manifest states a bound the buyer can see.
+pub const MAX_RETRIES: u32 = 10;
+
+/// A signed, immutable description of work to be done.
+#[derive(Clone, Debug, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct JobManifest {
+    pub workload: WorkloadRef,
+    /// The buyer. Carried in the payload as well as the envelope so that a
+    /// manifest quoted inside an offer or receipt still names its origin.
+    /// [`JobManifest::signed_by`] checks the two agree.
+    pub requester: Did,
+    #[serde(default)]
+    pub requirements: Requirements,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub input: Option<JobInput>,
+    pub execution: Execution,
+    pub economics: Economics,
+    #[serde(default)]
+    pub validation: ValidationPolicy,
+    #[serde(default)]
+    pub output: JobOutput,
+    pub announced_at: Timestamp,
+    /// After this instant the job is not schedulable. Offers referencing
+    /// it should be dropped.
+    pub deadline: Timestamp,
+}
+
+/// Which typed workload to run, and which versions of it will do.
+#[derive(Clone, Debug, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct WorkloadRef {
+    #[serde(rename = "type")]
+    pub type_id: String,
+    /// A semver range, e.g. `>=1 <2`. Absent means any version.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub version: Option<String>,
+}
+
+/// What a provider must have to be eligible.
+#[derive(Clone, Debug, Default, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct Requirements {
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub gpu: Option<GpuRequirement>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub cpu_cores: Option<u32>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    #[serde(rename = "memoryGiB")]
+    pub memory_gib: Option<Bound>,
+    /// Acceptable regions. Empty means the buyer does not care — and note
+    /// that a non-empty list can only match providers that chose to
+    /// disclose a region.
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub region: Vec<String>,
+    #[serde(default = "default_tier")]
+    pub trust_tier: TrustTier,
+    /// Explicit provider allowlist. Required for the `private` trust tier,
+    /// which means exactly "these identities and no others".
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub providers: Vec<Did>,
+}
+
+fn default_tier() -> TrustTier {
+    TrustTier::Community
+}
+
+#[derive(Clone, Debug, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct GpuRequirement {
+    #[serde(default = "one_u32")]
+    pub count: u32,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    #[serde(rename = "vramGiB")]
+    pub vram_gib: Option<Bound>,
+    /// Required runtime features, e.g. `cuda`, `nvenc`.
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub features: Vec<String>,
+}
+
+fn one_u32() -> u32 {
+    1
+}
+
+/// An inclusive numeric bound. At least one end must be set.
+#[derive(Clone, Copy, Debug, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct Bound {
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub min: Option<u32>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub max: Option<u32>,
+}
+
+impl Bound {
+    pub fn at_least(min: u32) -> Self {
+        Self {
+            min: Some(min),
+            max: None,
+        }
+    }
+
+    pub fn contains(&self, v: u32) -> bool {
+        self.min.is_none_or(|m| v >= m) && self.max.is_none_or(|m| v <= m)
+    }
+
+    fn validate(&self) -> Result<(), Error> {
+        match (self.min, self.max) {
+            (None, None) => Err(Error::Format("a bound must set min, max, or both".into())),
+            (Some(lo), Some(hi)) if lo > hi => {
+                Err(Error::Format(format!("bound min {lo} is above max {hi}")))
+            }
+            _ => Ok(()),
+        }
+    }
+}
+
+/// Where the job's input comes from.
+#[derive(Clone, Debug, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct JobInput {
+    /// Content address, e.g. `c0://blake3:…`.
+    ///
+    /// A content hash rather than a mutable URL: the provider can verify
+    /// it fetched what the buyer signed for, and the input can be served
+    /// by a cache, a storage provider, or an HTTP gateway without changing
+    /// the manifest or its hash.
+    #[serde(rename = "ref")]
+    pub reference: ContentHash,
+    /// How the bytes at `ref` are encrypted, if they are. Absent means
+    /// plaintext — appropriate for public inputs, not for private work.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub encryption: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub bytes: Option<u64>,
+}
+
+/// How the workload runs on the provider.
+#[derive(Clone, Debug, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct Execution {
+    pub timeout_seconds: u32,
+    #[serde(default)]
+    pub retry: u32,
+    #[serde(default)]
+    pub isolation: Isolation,
+    /// Digest of the runtime image or plugin artifact. Pinning it by
+    /// digest is what makes a receipt reproducible: "this input, through
+    /// exactly this code, produced this output".
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub runtime_digest: Option<ContentHash>,
+    /// Whether the workload may reach the network while it runs. Off by
+    /// default — a provider running untrusted work should have to opt in.
+    #[serde(default)]
+    pub network: bool,
+}
+
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "lowercase")]
+pub enum Isolation {
+    /// In-process, for first-party typed plugins the provider already
+    /// trusts.
+    Process,
+    /// Rootless container. The default for anything else.
+    #[default]
+    Container,
+    /// Full virtual machine.
+    Vm,
+}
+
+/// Price, settlement rail, and escrow.
+#[derive(Clone, Debug, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct Economics {
+    /// The most the buyer will pay. Offers above it are not eligible.
+    pub max_price: Money,
+    /// Which settlement implementation settles this job. Named, not
+    /// assumed: the protocol carries the choice so that adopting c0mpute
+    /// does not mean adopting one payment product.
+    pub settlement: SettlementAdapter,
+    #[serde(default)]
+    pub escrow: bool,
+}
+
+/// Limits on what comes back.
+#[derive(Clone, Copy, Debug, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct JobOutput {
+    /// How long the provider should keep the result available.
+    pub retention_seconds: u32,
+    /// Cap on the result size, so a provider knows what it is agreeing to
+    /// store and transfer before it bids.
+    pub max_bytes: u64,
+}
+
+impl Default for JobOutput {
+    fn default() -> Self {
+        Self {
+            retention_seconds: 3600,
+            max_bytes: 10 * 1024 * 1024,
+        }
+    }
+}
+
+impl JobManifest {
+    /// The job's id: the content hash of the canonical manifest.
+    pub fn id(&self) -> Result<ContentHash, Error> {
+        Ok(ContentHash::of(&canonicalize(self)?))
+    }
+
+    /// Whether the manifest's stated requester matches the identity that
+    /// sealed it. An envelope proves *someone* signed the manifest; this
+    /// proves it was the buyer the manifest names.
+    pub fn signed_by(&self, signer: &Did) -> bool {
+        &self.requester == signer
+    }
+
+    /// Whether the job is still schedulable at `now`.
+    pub fn is_open_at(&self, now: &Timestamp) -> bool {
+        !self.deadline.is_expired_at(now)
+    }
+}
+
+impl Payload for JobManifest {
+    const TYPE: &'static str = "c0mpute.job/v2";
+
+    fn expires_at(&self) -> Option<&Timestamp> {
+        Some(&self.deadline)
+    }
+
+    fn validate(&self) -> Result<(), Error> {
+        validate_workload_type(&self.workload.type_id)?;
+
+        if self.deadline <= self.announced_at {
+            return Err(Error::Format(format!(
+                "job deadline ({}) must be after announcedAt ({})",
+                self.deadline, self.announced_at
+            )));
+        }
+
+        if self.execution.timeout_seconds == 0 {
+            return Err(Error::Format(
+                "execution timeout must be greater than 0".into(),
+            ));
+        }
+        let window_ms = self.deadline.unix_ms() - self.announced_at.unix_ms();
+        let timeout_ms = i64::from(self.execution.timeout_seconds) * 1000;
+        if timeout_ms > window_ms {
+            return Err(Error::Format(format!(
+                "execution timeout of {}s cannot fit in the {}ms window before the deadline",
+                self.execution.timeout_seconds, window_ms
+            )));
+        }
+        if self.execution.retry > MAX_RETRIES {
+            return Err(Error::Format(format!(
+                "retry count {} exceeds the maximum of {MAX_RETRIES}",
+                self.execution.retry
+            )));
+        }
+
+        self.economics.max_price.validate()?;
+        self.economics.settlement.validate()?;
+        self.validation.validate()?;
+
+        if let Some(gpu) = &self.requirements.gpu {
+            if gpu.count == 0 {
+                return Err(Error::Format(
+                    "a GPU requirement must ask for at least one GPU".into(),
+                ));
+            }
+            if let Some(b) = &gpu.vram_gib {
+                b.validate()?;
+            }
+        }
+        if let Some(b) = &self.requirements.memory_gib {
+            b.validate()?;
+        }
+        if self.requirements.cpu_cores == Some(0) {
+            return Err(Error::Format(
+                "a CPU requirement must ask for at least one core".into(),
+            ));
+        }
+
+        // `private` means "this allowlist"; without one it silently
+        // degrades into "any provider that claims the private tier",
+        // which is the opposite of what the buyer asked for.
+        if self.requirements.trust_tier == TrustTier::Private
+            && self.requirements.providers.is_empty()
+        {
+            return Err(Error::Format(
+                "the private trust tier requires an explicit provider allowlist".into(),
+            ));
+        }
+
+        if self.output.max_bytes == 0 {
+            return Err(Error::Format(
+                "output maxBytes must be greater than 0".into(),
+            ));
+        }
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::envelope::Envelope;
+    use crate::identity::SigningIdentity;
+    use crate::types::{ValidationLevel, ValidationPolicy};
+
+    fn ts(s: &str) -> Timestamp {
+        Timestamp::parse(s).unwrap()
+    }
+
+    fn buyer() -> SigningIdentity {
+        SigningIdentity::from_seed(&[42u8; 32])
+    }
+
+    fn manifest() -> JobManifest {
+        JobManifest {
+            workload: WorkloadRef {
+                type_id: "infernet.inference".into(),
+                version: Some(">=1 <2".into()),
+            },
+            requester: buyer().did().clone(),
+            requirements: Requirements {
+                gpu: Some(GpuRequirement {
+                    count: 1,
+                    vram_gib: Some(Bound::at_least(24)),
+                    features: vec!["cuda".into()],
+                }),
+                cpu_cores: None,
+                memory_gib: Some(Bound::at_least(32)),
+                region: vec!["us-west".into()],
+                trust_tier: TrustTier::Standard,
+                providers: vec![],
+            },
+            input: Some(JobInput {
+                reference: ContentHash::of(b"prompts.jsonl"),
+                encryption: Some("recipient-selected".into()),
+                bytes: Some(4096),
+            }),
+            execution: Execution {
+                timeout_seconds: 120,
+                retry: 2,
+                isolation: Isolation::Container,
+                runtime_digest: Some(ContentHash::of(b"runtime image")),
+                network: false,
+            },
+            economics: Economics {
+                max_price: Money::new("0.10", "USD"),
+                settlement: SettlementAdapter::coinpay(),
+                escrow: true,
+            },
+            validation: ValidationPolicy {
+                level: ValidationLevel::Spotcheck,
+                redundancy: 1,
+                spotcheck_percent: Some(5),
+            },
+            output: JobOutput {
+                retention_seconds: 3600,
+                max_bytes: 10_485_760,
+            },
+            announced_at: ts("2026-09-06T16:00:00.000Z"),
+            deadline: ts("2026-09-06T16:10:00.000Z"),
+        }
+    }
+
+    #[test]
+    fn a_well_formed_manifest_validates_and_seals() {
+        let m = manifest();
+        m.validate().unwrap();
+        let env = Envelope::seal(&buyer(), m).unwrap();
+        let opened = env.open().unwrap();
+        assert!(opened.signed_by(&env.signer));
+    }
+
+    #[test]
+    fn job_id_is_the_content_hash_of_the_manifest() {
+        let a = manifest().id().unwrap();
+        let b = manifest().id().unwrap();
+        assert_eq!(a, b, "the same manifest must have the same id everywhere");
+
+        let mut changed = manifest();
+        changed.economics.max_price = Money::new("0.11", "USD");
+        assert_ne!(changed.id().unwrap(), a, "any change is a different job");
+    }
+
+    #[test]
+    fn job_id_does_not_depend_on_json_key_order() {
+        let m = manifest();
+        let id = m.id().unwrap();
+        // Round-trip through an untyped Value, which reorders nothing
+        // predictably, then back into a manifest.
+        let shuffled = serde_json::to_string(&serde_json::to_value(&m).unwrap()).unwrap();
+        let reparsed: JobManifest = serde_json::from_str(&shuffled).unwrap();
+        assert_eq!(reparsed.id().unwrap(), id);
+    }
+
+    #[test]
+    fn signed_by_catches_a_manifest_sealed_by_someone_else() {
+        let m = manifest();
+        let impostor = SigningIdentity::from_seed(&[43u8; 32]);
+        let env = Envelope::seal(&impostor, m).unwrap();
+        // The envelope is authentic — the impostor really did sign it —
+        // but it is not the requester the manifest names.
+        let opened = env.open().unwrap();
+        assert!(!opened.signed_by(&env.signer));
+    }
+
+    #[test]
+    fn deadline_must_follow_announcement() {
+        let mut m = manifest();
+        m.deadline = m.announced_at.clone();
+        assert!(m.validate().is_err());
+    }
+
+    #[test]
+    fn a_timeout_that_cannot_fit_before_the_deadline_is_rejected() {
+        let mut m = manifest();
+        m.execution.timeout_seconds = 3600; // 1h into a 10min window
+        assert!(m.validate().is_err());
+    }
+
+    #[test]
+    fn zero_timeout_is_rejected() {
+        let mut m = manifest();
+        m.execution.timeout_seconds = 0;
+        assert!(m.validate().is_err());
+    }
+
+    #[test]
+    fn excessive_retries_are_rejected() {
+        let mut m = manifest();
+        m.execution.retry = MAX_RETRIES + 1;
+        assert!(m.validate().is_err());
+    }
+
+    #[test]
+    fn the_private_tier_requires_an_allowlist() {
+        let mut m = manifest();
+        m.requirements.trust_tier = TrustTier::Private;
+        assert!(m.validate().is_err());
+
+        m.requirements.providers = vec![SigningIdentity::from_seed(&[9u8; 32]).did().clone()];
+        m.validate().unwrap();
+    }
+
+    #[test]
+    fn an_impossible_bound_is_rejected() {
+        let mut m = manifest();
+        m.requirements.memory_gib = Some(Bound {
+            min: Some(64),
+            max: Some(32),
+        });
+        assert!(m.validate().is_err());
+
+        m.requirements.memory_gib = Some(Bound {
+            min: None,
+            max: None,
+        });
+        assert!(m.validate().is_err());
+    }
+
+    #[test]
+    fn bounds_match_inclusively() {
+        assert!(Bound::at_least(24).contains(24));
+        assert!(Bound::at_least(24).contains(48));
+        assert!(!Bound::at_least(24).contains(23));
+        let range = Bound {
+            min: Some(8),
+            max: Some(16),
+        };
+        assert!(range.contains(8) && range.contains(16));
+        assert!(!range.contains(17));
+    }
+
+    #[test]
+    fn network_access_is_off_unless_asked_for() {
+        let json = r#"{"timeoutSeconds":60}"#;
+        let e: Execution = serde_json::from_str(json).unwrap();
+        assert!(
+            !e.network,
+            "untrusted workloads must not get the network by default"
+        );
+        assert_eq!(e.isolation, Isolation::Container);
+        assert_eq!(e.retry, 0);
+    }
+
+    #[test]
+    fn a_manifest_past_its_deadline_is_closed() {
+        let m = manifest();
+        assert!(m.is_open_at(&ts("2026-09-06T16:05:00.000Z")));
+        assert!(!m.is_open_at(&ts("2026-09-06T16:11:00.000Z")));
+    }
+
+    #[test]
+    fn manifest_round_trips_through_canonical_json() {
+        let env = Envelope::seal(&buyer(), manifest()).unwrap();
+        let json = env.to_canonical_json().unwrap();
+        assert!(json.contains("\"maxPrice\""));
+        let back: Envelope<JobManifest> = Envelope::from_json(&json).unwrap();
+        assert_eq!(
+            back.open().unwrap().id().unwrap(),
+            env.payload.id().unwrap()
+        );
+    }
+
+    #[test]
+    fn settlement_is_named_not_assumed() {
+        let mut m = manifest();
+        m.economics.settlement = SettlementAdapter("lightning".into());
+        m.validate().unwrap();
+        let env = Envelope::seal(&buyer(), m).unwrap();
+        assert!(env.to_canonical_json().unwrap().contains("\"lightning\""));
+    }
+}

--- a/node/crates/c0mpute-envelope/src/lib.rs
+++ b/node/crates/c0mpute-envelope/src/lib.rs
@@ -1,0 +1,114 @@
+//! Signed protocol envelopes for the c0mpute network.
+//!
+//! This crate is the spine of c0mpute v2: canonical serialization, native
+//! network identity, and the four payload types the open market runs on.
+//!
+//! ```text
+//! provider.advert/v1   a provider says what it can run, and until when
+//! job/v2               a buyer describes work, constraints, price, trust
+//! offer/v1             a provider quotes a price for one job
+//! receipt/v1           both sides sign what actually happened
+//! ```
+//!
+//! Everything a node needs in order to believe one of those four things
+//! is inside the message. There is no lookup against a registry, no shared
+//! database, and no hosted API in the verification path — which is the
+//! property that lets the network keep working when c0mpute.com does not.
+//!
+//! ## Deliberate non-dependencies
+//!
+//! This crate does not depend on libp2p, on any HTTP client, or on any
+//! settlement implementation. Transport, discovery, and payment are all
+//! bound at the edges:
+//!
+//! - identity is raw ed25519 bytes ([`SigningIdentity::from_seed`]), which
+//!   the transport layer supplies from the same key libp2p persists;
+//! - settlement is named by an open [`SettlementAdapter`] string rather
+//!   than a closed enum, so CoinPay is the default rather than a
+//!   requirement.
+//!
+//! Keeping those out is what makes "core protocol crates must not depend
+//! on hosted-service SDKs" a rule a build can enforce rather than a slogan.
+//!
+//! ## Example
+//!
+//! ```
+//! use c0mpute_envelope::{Envelope, Offer, Money, SigningIdentity, Timestamp, ContentHash};
+//!
+//! let provider = SigningIdentity::from_seed(&[7u8; 32]);
+//! let offer = Offer {
+//!     job: ContentHash::of(b"a job manifest"),
+//!     price: Money::new("0.042", "USD"),
+//!     expected_duration_ms: 12_000,
+//!     start_before: Timestamp::parse("2026-09-06T16:02:00.000Z").unwrap(),
+//!     expires_at: Timestamp::parse("2026-09-06T16:00:10.000Z").unwrap(),
+//!     capability_advert: None,
+//!     coordinator: false,
+//! };
+//!
+//! let sealed = Envelope::seal(&provider, offer).unwrap();
+//! let json = sealed.to_canonical_json().unwrap();
+//!
+//! // A peer that was never on the wire can still verify it.
+//! let received: Envelope<Offer> = Envelope::from_json(&json).unwrap();
+//! let verified = received.open().unwrap();
+//! assert_eq!(verified.price.amount, "0.042");
+//! ```
+
+pub mod advert;
+pub mod canonical;
+pub mod envelope;
+pub mod identity;
+pub mod job;
+pub mod offer;
+pub mod receipt;
+pub mod types;
+
+pub use advert::{Credential, GpuSpec, ProviderAdvert, ProviderCapabilities, ProviderTrust};
+pub use canonical::{canonicalize, canonicalize_to_string};
+pub use envelope::{DOMAIN, ENVELOPE_VERSION, Envelope, Payload};
+pub use identity::{DID_PREFIX, Did, EnvelopeSignature, SigningIdentity};
+pub use job::{Economics, Execution, Isolation, JobInput, JobManifest, JobOutput, Requirements};
+pub use offer::Offer;
+pub use receipt::{
+    Receipt, ReceiptAcceptance, SettlementRecord, ValidationOutcome, ValidationStatus,
+};
+pub use types::{
+    ContentHash, Money, SettlementAdapter, Timestamp, TrustTier, ValidationLevel, ValidationPolicy,
+};
+
+/// Everything that can go wrong reading or writing a protocol message.
+#[derive(Debug, thiserror::Error)]
+pub enum Error {
+    /// A value cannot be canonically serialized, so it cannot be signed:
+    /// a float, an out-of-range integer, or a non-ASCII object key.
+    #[error("value is not canonically serializable: {0}")]
+    NonCanonical(String),
+
+    /// A DID or signature could not be parsed.
+    #[error("identity error: {0}")]
+    Identity(String),
+
+    /// A payload is structurally invalid.
+    #[error("malformed payload: {0}")]
+    Format(String),
+
+    /// The signature does not match the signer and the bytes.
+    #[error("signature verification failed")]
+    BadSignature,
+
+    /// The envelope carries a different payload type than the caller
+    /// expected.
+    #[error("expected payload type {expected}, found {found}")]
+    TypeMismatch {
+        expected: &'static str,
+        found: String,
+    },
+
+    /// The payload was authentic but is no longer valid.
+    #[error("payload expired at {expired_at} (now {now})")]
+    Expired { expired_at: String, now: String },
+
+    #[error("JSON error: {0}")]
+    Json(#[from] serde_json::Error),
+}

--- a/node/crates/c0mpute-envelope/src/offer.rs
+++ b/node/crates/c0mpute-envelope/src/offer.rs
@@ -1,0 +1,277 @@
+//! `c0mpute.offer/v1` — a provider quotes a price for one specific job.
+//!
+//! An offer is the moment the market actually happens, and it is where the
+//! v2 direction's central architectural claim gets cashed out: the offer
+//! is *signed by the provider* and *selected by the buyer*. Nothing in
+//! between decides. A gateway may collect offers on a buyer's behalf, and
+//! an indexer may have suggested which providers to ask, but neither can
+//! manufacture an offer, and neither gets to pick.
+//!
+//! Offers are short-lived by construction. A quote is a promise about
+//! capacity the provider has *now*; letting it linger would mean bidding
+//! on hardware that is already busy.
+
+use serde::{Deserialize, Serialize};
+
+use crate::Error;
+use crate::envelope::Payload;
+use crate::job::JobManifest;
+use crate::types::{ContentHash, Money, Timestamp};
+
+/// A signed quote for one job.
+#[derive(Clone, Debug, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct Offer {
+    /// The job being bid on, by [`JobManifest::id`].
+    pub job: ContentHash,
+    /// The price the provider will do it for. Binding, unlike the
+    /// indicative rates in an advert.
+    pub price: Money,
+    /// How long the provider expects execution to take.
+    pub expected_duration_ms: u64,
+    /// The provider commits to starting before this instant, if awarded.
+    pub start_before: Timestamp,
+    /// After this, the quote is void. Must not be later than
+    /// `start_before` — a quote you can accept after the promised start
+    /// time is not a quote.
+    pub expires_at: Timestamp,
+    /// The advert this quote is backed by, by content hash. Lets a buyer
+    /// tie the price to the capabilities it was offered against, and lets
+    /// a receipt record which claim of capacity was relied on.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub capability_advert: Option<ContentHash>,
+    /// Whether this provider is willing to act as the ephemeral job
+    /// coordinator for a multi-provider workload (§15).
+    ///
+    /// Per-job and per-offer, never a standing role: a coordinator elected
+    /// for one distributed-inference run has no authority over any other
+    /// job, which is what keeps it from becoming a control plane.
+    #[serde(default)]
+    pub coordinator: bool,
+}
+
+impl Offer {
+    /// Check this offer against the job it claims to bid on.
+    ///
+    /// Runs the constraints a buyer must not skip: right job, price within
+    /// the cap, and enough time to finish before the deadline. Reputation,
+    /// latency, and diversity are *policy* and live in the scheduler; the
+    /// checks here are the ones where accepting a failing offer is simply
+    /// a bug.
+    pub fn check_against(&self, job: &JobManifest) -> Result<(), Error> {
+        let job_id = job.id()?;
+        if self.job != job_id {
+            return Err(Error::Format(format!(
+                "offer is for job {} but was checked against {job_id}",
+                self.job
+            )));
+        }
+        if !self.price.is_within(&job.economics.max_price)? {
+            return Err(Error::Format(format!(
+                "offer price {} {} exceeds the job's maximum of {} {}",
+                self.price.amount,
+                self.price.currency,
+                job.economics.max_price.amount,
+                job.economics.max_price.currency
+            )));
+        }
+        let finish_by = self
+            .start_before
+            .unix_ms()
+            .saturating_add(self.expected_duration_ms as i64);
+        if finish_by > job.deadline.unix_ms() {
+            return Err(Error::Format(format!(
+                "offer would start as late as {} and run {}ms, finishing after the job deadline {}",
+                self.start_before, self.expected_duration_ms, job.deadline
+            )));
+        }
+        Ok(())
+    }
+
+    /// True when this offer is still acceptable at `now`.
+    pub fn is_live_at(&self, now: &Timestamp) -> bool {
+        !self.expires_at.is_expired_at(now)
+    }
+}
+
+impl Payload for Offer {
+    const TYPE: &'static str = "c0mpute.offer/v1";
+
+    fn expires_at(&self) -> Option<&Timestamp> {
+        Some(&self.expires_at)
+    }
+
+    fn validate(&self) -> Result<(), Error> {
+        self.price.validate()?;
+        if self.expected_duration_ms == 0 {
+            return Err(Error::Format(
+                "an offer must estimate a non-zero duration; a free instant is not a quote".into(),
+            ));
+        }
+        if self.expires_at > self.start_before {
+            return Err(Error::Format(format!(
+                "offer expiresAt ({}) must not be after startBefore ({}); \
+                 a quote acceptable after its promised start time is not binding",
+                self.expires_at, self.start_before
+            )));
+        }
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::envelope::Envelope;
+    use crate::identity::SigningIdentity;
+    use crate::job::{Economics, Execution, JobManifest, JobOutput, Requirements, WorkloadRef};
+    use crate::types::SettlementAdapter;
+
+    fn ts(s: &str) -> Timestamp {
+        Timestamp::parse(s).unwrap()
+    }
+
+    fn provider() -> SigningIdentity {
+        SigningIdentity::from_seed(&[77u8; 32])
+    }
+
+    fn job() -> JobManifest {
+        JobManifest {
+            workload: WorkloadRef {
+                type_id: "transcode.ffmpeg".into(),
+                version: None,
+            },
+            requester: SigningIdentity::from_seed(&[11u8; 32]).did().clone(),
+            requirements: Requirements::default(),
+            input: None,
+            execution: Execution {
+                timeout_seconds: 120,
+                retry: 0,
+                isolation: Default::default(),
+                runtime_digest: None,
+                network: false,
+            },
+            economics: Economics {
+                max_price: Money::new("0.10", "USD"),
+                settlement: SettlementAdapter::coinpay(),
+                escrow: true,
+            },
+            validation: Default::default(),
+            output: JobOutput::default(),
+            announced_at: ts("2026-09-06T16:00:00.000Z"),
+            deadline: ts("2026-09-06T16:10:00.000Z"),
+        }
+    }
+
+    fn offer_for(job: &JobManifest) -> Offer {
+        Offer {
+            job: job.id().unwrap(),
+            price: Money::new("0.042", "USD"),
+            expected_duration_ms: 12_000,
+            start_before: ts("2026-09-06T16:02:00.000Z"),
+            expires_at: ts("2026-09-06T16:00:10.000Z"),
+            capability_advert: Some(ContentHash::of(b"advert")),
+            coordinator: false,
+        }
+    }
+
+    #[test]
+    fn a_well_formed_offer_seals_and_checks_out() {
+        let j = job();
+        let o = offer_for(&j);
+        o.validate().unwrap();
+        o.check_against(&j).unwrap();
+        let env = Envelope::seal(&provider(), o).unwrap();
+        assert_eq!(env.open().unwrap().price.amount, "0.042");
+    }
+
+    #[test]
+    fn an_offer_for_a_different_job_is_rejected() {
+        let j = job();
+        let mut other = job();
+        other.economics.max_price = Money::new("0.20", "USD");
+        let o = offer_for(&other);
+        assert!(o.check_against(&j).is_err());
+    }
+
+    #[test]
+    fn an_over_cap_offer_is_rejected_by_value_not_by_string() {
+        let j = job(); // cap is "0.10"
+        let mut o = offer_for(&j);
+        // Lexically "0.09" > "0.10"; a string comparison would wrongly
+        // reject this, and wrongly accept "0.9".
+        o.price = Money::new("0.09", "USD");
+        o.check_against(&j).unwrap();
+
+        o.price = Money::new("0.9", "USD");
+        assert!(o.check_against(&j).is_err());
+    }
+
+    #[test]
+    fn an_offer_that_cannot_finish_before_the_deadline_is_rejected() {
+        let j = job();
+        let mut o = offer_for(&j);
+        // Starts at 16:02, runs 9 minutes, deadline is 16:10.
+        o.expected_duration_ms = 9 * 60 * 1000;
+        assert!(o.check_against(&j).is_err());
+    }
+
+    #[test]
+    fn an_offer_in_the_wrong_currency_is_rejected_rather_than_converted() {
+        let j = job();
+        let mut o = offer_for(&j);
+        o.price = Money::new("0.042", "USDC");
+        assert!(
+            o.check_against(&j).is_err(),
+            "the protocol has no exchange rate and must not guess one"
+        );
+    }
+
+    #[test]
+    fn an_offer_acceptable_after_its_promised_start_is_rejected() {
+        let j = job();
+        let mut o = offer_for(&j);
+        o.expires_at = ts("2026-09-06T16:03:00.000Z"); // after start_before
+        assert!(o.validate().is_err());
+    }
+
+    #[test]
+    fn a_zero_duration_offer_is_rejected() {
+        let j = job();
+        let mut o = offer_for(&j);
+        o.expected_duration_ms = 0;
+        assert!(o.validate().is_err());
+    }
+
+    #[test]
+    fn offers_go_stale() {
+        let j = job();
+        let o = offer_for(&j);
+        assert!(o.is_live_at(&ts("2026-09-06T16:00:05.000Z")));
+        assert!(!o.is_live_at(&ts("2026-09-06T16:00:11.000Z")));
+
+        let env = Envelope::seal(&provider(), o).unwrap();
+        assert!(matches!(
+            env.open_fresh(&ts("2026-09-06T16:05:00.000Z")).unwrap_err(),
+            Error::Expired { .. }
+        ));
+    }
+
+    #[test]
+    fn a_tampered_price_does_not_survive_the_signature() {
+        let j = job();
+        let mut env = Envelope::seal(&provider(), offer_for(&j)).unwrap();
+        env.payload.price = Money::new("0.001", "USD");
+        assert!(matches!(env.open().unwrap_err(), Error::BadSignature));
+    }
+
+    #[test]
+    fn coordinator_willingness_is_off_by_default() {
+        let json = r#"{"job":"blake3:00","price":{"amount":"1","currency":"USD"},
+                       "expectedDurationMs":10,"startBefore":"2026-09-06T16:02:00.000Z",
+                       "expiresAt":"2026-09-06T16:00:10.000Z"}"#;
+        let o: Offer = serde_json::from_str(json).unwrap();
+        assert!(!o.coordinator);
+        assert!(o.capability_advert.is_none());
+    }
+}

--- a/node/crates/c0mpute-envelope/src/receipt.rs
+++ b/node/crates/c0mpute-envelope/src/receipt.rs
@@ -1,0 +1,386 @@
+//! `c0mpute.receipt/v1` — what actually happened, signed.
+//!
+//! A receipt is the network's durable record and the input to every
+//! reputation calculation. It names the job, the offer that priced it, the
+//! runtime that ran it, the input and output by hash, what the validator
+//! concluded, and what was paid.
+//!
+//! **Reputation is derived, not stored.** There is no global score and no
+//! authoritative table holding one. A peer that has collected receipts can
+//! compute a provider's completion rate, dispute rate, and offer accuracy
+//! for itself, and two peers weighting those differently are both correct.
+//! That is what makes reputation survive an operator's database going
+//! away, or an operator deciding it does not like you.
+//!
+//! ## Two signatures, two envelopes
+//!
+//! The v2 direction shows a receipt carrying a `signatures` object with a
+//! provider and a buyer entry. This crate models the same fact as a
+//! provider-sealed `Envelope<Receipt>` plus a buyer-sealed
+//! [`ReceiptAcceptance`] naming that receipt by hash. Two envelopes rather
+//! than one multi-signature blob, because:
+//!
+//! - the signatures are made at different times, by parties who may never
+//!   be online together, and one arriving without the other is the normal
+//!   case, not a malformed message;
+//! - a buyer needs to be able to say *no* as well as yes, and a
+//!   countersignature field has no way to express a rejection;
+//! - both then reuse one signing and verification path, so there is no
+//!   second, subtly different way to check a signature.
+
+use serde::{Deserialize, Serialize};
+
+use crate::Error;
+use crate::advert::validate_workload_type;
+use crate::envelope::Payload;
+use crate::identity::Did;
+use crate::types::{ContentHash, Money, SettlementAdapter, Timestamp, ValidationPolicy};
+
+/// A provider's signed statement of what it did.
+#[derive(Clone, Debug, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct Receipt {
+    /// The job, by [`crate::JobManifest::id`].
+    pub job: ContentHash,
+    pub buyer: Did,
+    pub provider: Did,
+    /// The independent validator, when one was used (levels L2 and up).
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub validator: Option<Did>,
+    pub workload: String,
+    /// The offer that set the price, by content hash. Ties the amount paid
+    /// back to a signed quote instead of an assertion.
+    pub offer: ContentHash,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub input_hash: Option<ContentHash>,
+    /// Absent when the job did not complete — a failure is still a receipt,
+    /// and a provider's failures are part of its record.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub output_hash: Option<ContentHash>,
+    /// The pinned runtime that produced the output. With the input hash,
+    /// this is what makes a result reproducible by a third party.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub runtime_hash: Option<ContentHash>,
+    pub started_at: Timestamp,
+    pub completed_at: Timestamp,
+    pub price: Money,
+    pub validation: ValidationOutcome,
+    pub settlement: SettlementRecord,
+}
+
+/// What the chosen validation policy concluded.
+#[derive(Clone, Debug, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct ValidationOutcome {
+    /// The policy the job asked for, repeated here so a reader of the
+    /// receipt alone knows how much the result was actually checked.
+    pub policy: ValidationPolicy,
+    pub status: ValidationStatus,
+    /// Free-text detail, e.g. which schema check failed.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub detail: Option<String>,
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "lowercase")]
+pub enum ValidationStatus {
+    /// The result passed and the job should settle.
+    Accepted,
+    /// The result failed validation. No settlement.
+    Rejected,
+    /// The parties disagree; settlement is held pending resolution.
+    Disputed,
+    /// The job did not produce a result to validate (timeout, crash,
+    /// provider withdrawal).
+    Failed,
+}
+
+/// How the money moved, or did not.
+#[derive(Clone, Debug, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct SettlementRecord {
+    pub adapter: SettlementAdapter,
+    /// The adapter's own identifier for the transfer — a CoinPay receipt
+    /// id, a Lightning payment hash, an invoice number. Opaque here on
+    /// purpose: the protocol records *that* an adapter settled and how to
+    /// look it up, and knows nothing about any adapter's internals.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub reference: Option<String>,
+    #[serde(default)]
+    pub settled: bool,
+}
+
+impl Receipt {
+    /// Wall-clock execution time.
+    pub fn duration_ms(&self) -> i64 {
+        self.completed_at.unix_ms() - self.started_at.unix_ms()
+    }
+
+    /// Whether this receipt counts as a successful job for reputation.
+    pub fn is_success(&self) -> bool {
+        self.validation.status == ValidationStatus::Accepted && self.output_hash.is_some()
+    }
+
+    /// Whether the provider's quoted duration held up. Offer accuracy is
+    /// one of the more useful reputation inputs precisely because it is
+    /// cheap to compute and hard to fake: the quote was signed before the
+    /// work, the receipt after it.
+    pub fn beat_estimate(&self, quoted_ms: u64) -> bool {
+        self.duration_ms() <= quoted_ms as i64
+    }
+}
+
+impl Payload for Receipt {
+    const TYPE: &'static str = "c0mpute.receipt/v1";
+
+    // Receipts do not expire. They are the historical record; a two-year-old
+    // receipt is exactly as valid a statement about the past as a fresh one.
+
+    fn validate(&self) -> Result<(), Error> {
+        validate_workload_type(&self.workload)?;
+        self.price.validate()?;
+        self.settlement.adapter.validate()?;
+        self.validation.policy.validate()?;
+
+        if self.completed_at < self.started_at {
+            return Err(Error::Format(format!(
+                "receipt completedAt ({}) is before startedAt ({})",
+                self.completed_at, self.started_at
+            )));
+        }
+        if self.buyer == self.provider {
+            return Err(Error::Format(
+                "buyer and provider must be different identities".into(),
+            ));
+        }
+        if self.validation.status == ValidationStatus::Accepted && self.output_hash.is_none() {
+            return Err(Error::Format(
+                "an accepted result must record an output hash".into(),
+            ));
+        }
+        if self.settlement.settled && self.validation.status != ValidationStatus::Accepted {
+            return Err(Error::Format(format!(
+                "settlement recorded for a result whose validation status is {:?}; \
+                 only accepted work settles",
+                self.validation.status
+            )));
+        }
+        Ok(())
+    }
+}
+
+/// The buyer's countersignature on a receipt — or its refusal.
+///
+/// Sealed by the buyer in its own envelope, naming the provider's sealed
+/// receipt by content hash.
+#[derive(Clone, Debug, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct ReceiptAcceptance {
+    /// Content hash of the provider's sealed `Envelope<Receipt>`, from
+    /// [`crate::Envelope::content_hash`].
+    pub receipt: ContentHash,
+    /// True to accept, false to dispute.
+    pub accepted: bool,
+    pub signed_at: Timestamp,
+    /// Why, when disputing.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub reason: Option<String>,
+}
+
+impl Payload for ReceiptAcceptance {
+    const TYPE: &'static str = "c0mpute.receipt.acceptance/v1";
+
+    fn validate(&self) -> Result<(), Error> {
+        if !self.accepted && self.reason.as_ref().is_none_or(|r| r.trim().is_empty()) {
+            return Err(Error::Format(
+                "a disputed receipt must state a reason; an unexplained dispute cannot be \
+                 weighed against the provider's record"
+                    .into(),
+            ));
+        }
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::envelope::Envelope;
+    use crate::identity::SigningIdentity;
+    use crate::types::{ValidationLevel, ValidationPolicy};
+
+    fn ts(s: &str) -> Timestamp {
+        Timestamp::parse(s).unwrap()
+    }
+
+    fn buyer() -> SigningIdentity {
+        SigningIdentity::from_seed(&[11u8; 32])
+    }
+
+    fn provider() -> SigningIdentity {
+        SigningIdentity::from_seed(&[77u8; 32])
+    }
+
+    fn receipt() -> Receipt {
+        Receipt {
+            job: ContentHash::of(b"job manifest"),
+            buyer: buyer().did().clone(),
+            provider: provider().did().clone(),
+            validator: None,
+            workload: "infernet.inference".into(),
+            offer: ContentHash::of(b"sealed offer"),
+            input_hash: Some(ContentHash::of(b"input")),
+            output_hash: Some(ContentHash::of(b"output")),
+            runtime_hash: Some(ContentHash::of(b"runtime")),
+            started_at: ts("2026-09-06T16:01:00.000Z"),
+            completed_at: ts("2026-09-06T16:01:12.000Z"),
+            price: Money::new("0.042", "USD"),
+            validation: ValidationOutcome {
+                policy: ValidationPolicy {
+                    level: ValidationLevel::Spotcheck,
+                    redundancy: 1,
+                    spotcheck_percent: Some(5),
+                },
+                status: ValidationStatus::Accepted,
+                detail: None,
+            },
+            settlement: SettlementRecord {
+                adapter: SettlementAdapter::coinpay(),
+                reference: Some("cp_rcpt_01J8…".into()),
+                settled: true,
+            },
+        }
+    }
+
+    #[test]
+    fn a_well_formed_receipt_seals_and_opens() {
+        let r = receipt();
+        r.validate().unwrap();
+        let env = Envelope::seal(&provider(), r).unwrap();
+        let opened = env.open().unwrap();
+        assert!(opened.is_success());
+        assert_eq!(opened.duration_ms(), 12_000);
+        assert!(opened.beat_estimate(12_000));
+        assert!(!opened.beat_estimate(11_999));
+    }
+
+    #[test]
+    fn receipts_do_not_expire() {
+        let env = Envelope::seal(&provider(), receipt()).unwrap();
+        // Years later, the record still verifies.
+        env.open_fresh(&ts("2031-01-01T00:00:00.000Z")).unwrap();
+    }
+
+    #[test]
+    fn a_failure_is_still_a_valid_receipt() {
+        let mut r = receipt();
+        r.output_hash = None;
+        r.validation.status = ValidationStatus::Failed;
+        r.validation.detail = Some("provider timed out".into());
+        r.settlement.settled = false;
+        r.settlement.reference = None;
+        r.validate().unwrap();
+        assert!(!r.is_success());
+    }
+
+    #[test]
+    fn an_accepted_result_must_have_an_output() {
+        let mut r = receipt();
+        r.output_hash = None;
+        assert!(r.validate().is_err());
+    }
+
+    #[test]
+    fn settlement_cannot_be_recorded_for_unaccepted_work() {
+        let mut r = receipt();
+        r.validation.status = ValidationStatus::Rejected;
+        r.output_hash = None;
+        // settled is still true from the fixture.
+        assert!(r.validate().is_err());
+    }
+
+    #[test]
+    fn completion_cannot_precede_start() {
+        let mut r = receipt();
+        r.completed_at = ts("2026-09-06T16:00:00.000Z");
+        assert!(r.validate().is_err());
+    }
+
+    #[test]
+    fn a_self_dealt_receipt_is_rejected() {
+        let mut r = receipt();
+        r.provider = r.buyer.clone();
+        assert!(r.validate().is_err());
+    }
+
+    #[test]
+    fn a_tampered_price_does_not_survive_the_signature() {
+        let mut env = Envelope::seal(&provider(), receipt()).unwrap();
+        env.payload.price = Money::new("999", "USD");
+        assert!(matches!(env.open().unwrap_err(), Error::BadSignature));
+    }
+
+    #[test]
+    fn the_buyer_countersigns_the_providers_sealed_receipt() {
+        let sealed = Envelope::seal(&provider(), receipt()).unwrap();
+        let acceptance = ReceiptAcceptance {
+            receipt: sealed.content_hash().unwrap(),
+            accepted: true,
+            signed_at: ts("2026-09-06T16:01:20.000Z"),
+            reason: None,
+        };
+        let counter = Envelope::seal(&buyer(), acceptance).unwrap();
+
+        let opened = counter.open().unwrap();
+        assert_eq!(opened.receipt, sealed.content_hash().unwrap());
+        assert_eq!(counter.signer.as_str(), buyer().did().as_str());
+    }
+
+    #[test]
+    fn a_countersignature_does_not_transfer_to_another_receipt() {
+        let sealed = Envelope::seal(&provider(), receipt()).unwrap();
+        let mut other = receipt();
+        other.price = Money::new("0.500", "USD");
+        let other_sealed = Envelope::seal(&provider(), other).unwrap();
+
+        let counter = Envelope::seal(
+            &buyer(),
+            ReceiptAcceptance {
+                receipt: sealed.content_hash().unwrap(),
+                accepted: true,
+                signed_at: ts("2026-09-06T16:01:20.000Z"),
+                reason: None,
+            },
+        )
+        .unwrap();
+
+        // The acceptance names one receipt hash and only that one.
+        assert_ne!(
+            counter.open().unwrap().receipt,
+            other_sealed.content_hash().unwrap()
+        );
+    }
+
+    #[test]
+    fn a_dispute_must_say_why() {
+        let bare = ReceiptAcceptance {
+            receipt: ContentHash::of(b"r"),
+            accepted: false,
+            signed_at: ts("2026-09-06T16:01:20.000Z"),
+            reason: None,
+        };
+        assert!(bare.validate().is_err());
+
+        let blank = ReceiptAcceptance {
+            reason: Some("   ".into()),
+            ..bare.clone()
+        };
+        assert!(blank.validate().is_err());
+
+        let explained = ReceiptAcceptance {
+            reason: Some("output failed schema validation".into()),
+            ..bare
+        };
+        explained.validate().unwrap();
+    }
+}

--- a/node/crates/c0mpute-envelope/src/types.rs
+++ b/node/crates/c0mpute-envelope/src/types.rs
@@ -1,0 +1,788 @@
+//! Value types shared by every c0mpute protocol payload.
+//!
+//! Each one exists to remove an ambiguity that would otherwise show up as
+//! two nodes computing different hashes for the same logical object:
+//! money is a decimal string rather than a float, timestamps have exactly
+//! one legal spelling, and content hashes carry their algorithm.
+
+use std::cmp::Ordering;
+
+use serde::{Deserialize, Serialize};
+
+use crate::Error;
+
+// ────────────────────────────────────────────────────────────────────────
+// Content hashes
+// ────────────────────────────────────────────────────────────────────────
+
+/// A self-describing content hash: `blake3:<64 hex chars>`.
+///
+/// c0mpute hashes with BLAKE3, matching `c0mpute-proto::Hash` and the
+/// existing chunk store. The algorithm prefix is on the wire so a future
+/// migration does not require guessing at the length. (The v2 direction
+/// PRD writes `sha256:` in its illustrative JSON; the repository already
+/// content-addresses chunks with BLAKE3, and splitting the two would mean
+/// two hash trees over the same bytes.)
+#[derive(Clone, PartialEq, Eq, Hash)]
+pub struct ContentHash {
+    algo: String,
+    hex: String,
+}
+
+impl ContentHash {
+    /// Hash bytes with the default algorithm.
+    pub fn of(bytes: &[u8]) -> Self {
+        Self {
+            algo: "blake3".into(),
+            hex: hex::encode(blake3::hash(bytes).as_bytes()),
+        }
+    }
+
+    pub fn parse(s: &str) -> Result<Self, Error> {
+        let (algo, hex_part) = s
+            .split_once(':')
+            .ok_or_else(|| Error::Format(format!("content hash {s:?} must be `<algo>:<hex>`")))?;
+        if algo.is_empty()
+            || !algo
+                .chars()
+                .all(|c| c.is_ascii_lowercase() || c.is_ascii_digit())
+        {
+            return Err(Error::Format(format!(
+                "content-hash algorithm {algo:?} must be lowercase alphanumeric"
+            )));
+        }
+        if hex_part.is_empty()
+            || hex_part.len() % 2 != 0
+            || !hex_part
+                .chars()
+                .all(|c| c.is_ascii_hexdigit() && !c.is_ascii_uppercase())
+        {
+            return Err(Error::Format(format!(
+                "content-hash digest {hex_part:?} must be non-empty lowercase hex"
+            )));
+        }
+        Ok(Self {
+            algo: algo.to_string(),
+            hex: hex_part.to_string(),
+        })
+    }
+
+    pub fn algorithm(&self) -> &str {
+        &self.algo
+    }
+
+    pub fn to_wire(&self) -> String {
+        format!("{}:{}", self.algo, self.hex)
+    }
+
+    /// The network-native content URI from the v2 direction, e.g.
+    /// `c0://blake3:0f2c…`. Resolvable from a local cache, a c0mpute
+    /// storage provider, or an HTTP gateway — the URI itself names no host,
+    /// which is what makes it survive any one of them disappearing.
+    pub fn to_c0_uri(&self) -> String {
+        format!("c0://{}", self.to_wire())
+    }
+
+    /// Parse either the bare `blake3:…` form or a `c0://blake3:…` URI.
+    pub fn parse_uri(s: &str) -> Result<Self, Error> {
+        Self::parse(s.strip_prefix("c0://").unwrap_or(s))
+    }
+}
+
+impl std::fmt::Display for ContentHash {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{}:{}", self.algo, self.hex)
+    }
+}
+
+impl std::fmt::Debug for ContentHash {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "ContentHash({self})")
+    }
+}
+
+impl Serialize for ContentHash {
+    fn serialize<S: serde::Serializer>(&self, s: S) -> Result<S::Ok, S::Error> {
+        s.serialize_str(&self.to_wire())
+    }
+}
+
+impl<'de> Deserialize<'de> for ContentHash {
+    fn deserialize<D: serde::Deserializer<'de>>(d: D) -> Result<Self, D::Error> {
+        let s = String::deserialize(d)?;
+        ContentHash::parse(&s).map_err(serde::de::Error::custom)
+    }
+}
+
+// ────────────────────────────────────────────────────────────────────────
+// Money
+// ────────────────────────────────────────────────────────────────────────
+
+/// A price. The amount is a **decimal string**, never a float.
+///
+/// `0.1 + 0.2 != 0.3` in binary floating point, and JSON encoders disagree
+/// about how to render a double. Either one is enough to make a buyer and a
+/// provider hash the same offer differently. A string sidesteps both, and
+/// [`crate::canonical`] refuses to sign a float anywhere in a payload.
+#[derive(Clone, PartialEq, Eq, Debug, Serialize, Deserialize)]
+pub struct Money {
+    /// Plain decimal, e.g. `"0.042"`. No exponent, no thousands separator,
+    /// no sign.
+    pub amount: String,
+    /// ISO-4217 code for fiat (`"USD"`) or the asset symbol for crypto
+    /// (`"USDC"`). Compared case-sensitively; use upper case.
+    pub currency: String,
+}
+
+impl Money {
+    pub fn new(amount: impl Into<String>, currency: impl Into<String>) -> Self {
+        Self {
+            amount: amount.into(),
+            currency: currency.into(),
+        }
+    }
+
+    /// Check that the amount is a well-formed non-negative decimal and the
+    /// currency looks like a symbol.
+    pub fn validate(&self) -> Result<(), Error> {
+        parse_decimal(&self.amount)?;
+        if self.currency.is_empty()
+            || !self
+                .currency
+                .chars()
+                .all(|c| c.is_ascii_uppercase() || c.is_ascii_digit())
+        {
+            return Err(Error::Format(format!(
+                "currency {:?} must be an uppercase alphanumeric symbol",
+                self.currency
+            )));
+        }
+        Ok(())
+    }
+
+    /// Compare two amounts. Errors if the currencies differ — the protocol
+    /// deliberately has no exchange-rate opinion, so a cross-currency
+    /// comparison is a caller bug, not a silent `false`.
+    pub fn cmp_amount(&self, other: &Money) -> Result<Ordering, Error> {
+        if self.currency != other.currency {
+            return Err(Error::Format(format!(
+                "cannot compare {} with {}: no exchange rate at the protocol layer",
+                self.currency, other.currency
+            )));
+        }
+        let (a_int, a_frac) = parse_decimal(&self.amount)?;
+        let (b_int, b_frac) = parse_decimal(&other.amount)?;
+        Ok(a_int.cmp(&b_int).then_with(|| {
+            let width = a_frac.len().max(b_frac.len());
+            let pad = |s: &str| -> u128 {
+                let padded = format!("{s:0<width$}");
+                padded.parse().unwrap_or(0)
+            };
+            pad(&a_frac).cmp(&pad(&b_frac))
+        }))
+    }
+
+    /// True when this amount is within (less than or equal to) `cap`.
+    pub fn is_within(&self, cap: &Money) -> Result<bool, Error> {
+        Ok(self.cmp_amount(cap)? != Ordering::Greater)
+    }
+}
+
+/// Split a decimal string into (integer part, fractional digits).
+fn parse_decimal(s: &str) -> Result<(u128, String), Error> {
+    let bad = |why: &str| Error::Format(format!("amount {s:?} {why}"));
+    if s.is_empty() {
+        return Err(bad("is empty"));
+    }
+    let (int_part, frac_part) = match s.split_once('.') {
+        Some((i, f)) => (i, f),
+        None => (s, ""),
+    };
+    if int_part.is_empty() || !int_part.chars().all(|c| c.is_ascii_digit()) {
+        return Err(bad("must have a digits-only integer part"));
+    }
+    if int_part.len() > 1 && int_part.starts_with('0') {
+        return Err(bad("must not have leading zeros"));
+    }
+    if s.contains('.') && (frac_part.is_empty() || !frac_part.chars().all(|c| c.is_ascii_digit())) {
+        return Err(bad("must have digits after the decimal point"));
+    }
+    if frac_part.len() > 30 {
+        return Err(bad("has more than 30 fractional digits"));
+    }
+    let int_value: u128 = int_part
+        .parse()
+        .map_err(|_| bad("has too large an integer part"))?;
+    Ok((int_value, frac_part.to_string()))
+}
+
+// ────────────────────────────────────────────────────────────────────────
+// Timestamps
+// ────────────────────────────────────────────────────────────────────────
+
+/// An instant, spelled exactly one way: `YYYY-MM-DDTHH:MM:SS.sssZ`.
+///
+/// Always UTC, always millisecond precision. That is precisely what
+/// JavaScript's `Date.prototype.toISOString()` emits, so an agent or
+/// browser client produces canonical output without a library. Any other
+/// spelling of the same instant — a `+00:00` offset, a dropped
+/// milliseconds field, a lowercase `z` — is rejected rather than
+/// normalized, because normalizing after signing would change the bytes
+/// the signature covers.
+#[derive(Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+pub struct Timestamp {
+    text: String,
+    unix_ms: i64,
+}
+
+impl Timestamp {
+    /// Build from milliseconds since the Unix epoch.
+    pub fn from_unix_ms(unix_ms: i64) -> Result<Self, Error> {
+        let (days, ms_of_day) = (
+            unix_ms.div_euclid(86_400_000),
+            unix_ms.rem_euclid(86_400_000),
+        );
+        let (y, m, d) = civil_from_days(days);
+        let (ms, rest) = (ms_of_day % 1000, ms_of_day / 1000);
+        let (s, rest) = (rest % 60, rest / 60);
+        let (min, h) = (rest % 60, rest / 60);
+        Ok(Self {
+            text: format!("{y:04}-{m:02}-{d:02}T{h:02}:{min:02}:{s:02}.{ms:03}Z"),
+            unix_ms,
+        })
+    }
+
+    /// Parse the one legal spelling.
+    pub fn parse(s: &str) -> Result<Self, Error> {
+        let bad = |why: &str| {
+            Error::Format(format!(
+                "timestamp {s:?} {why}; the only legal form is YYYY-MM-DDTHH:MM:SS.sssZ (UTC)"
+            ))
+        };
+        let b = s.as_bytes();
+        if b.len() != 24 {
+            return Err(bad("has the wrong length"));
+        }
+        if b[4] != b'-' || b[7] != b'-' || b[10] != b'T' || b[13] != b':' || b[16] != b':' {
+            return Err(bad("has misplaced separators"));
+        }
+        if b[19] != b'.' || b[23] != b'Z' {
+            return Err(bad("must end with .sssZ"));
+        }
+        let num = |range: std::ops::Range<usize>| -> Result<i64, Error> {
+            let part = &s[range];
+            if !part.chars().all(|c| c.is_ascii_digit()) {
+                return Err(bad("has a non-digit where a number belongs"));
+            }
+            part.parse().map_err(|_| bad("has an unparseable number"))
+        };
+        let (y, mo, d) = (num(0..4)?, num(5..7)?, num(8..10)?);
+        let (h, mi, sec, ms) = (num(11..13)?, num(14..16)?, num(17..19)?, num(20..23)?);
+
+        if !(1..=12).contains(&mo) {
+            return Err(bad("has a month outside 1-12"));
+        }
+        if d < 1 || d > days_in_month(y, mo) {
+            return Err(bad("has a day that does not exist in that month"));
+        }
+        if h > 23 || mi > 59 || sec > 59 {
+            return Err(bad("has an out-of-range time field"));
+        }
+
+        let unix_ms =
+            days_from_civil(y, mo, d) * 86_400_000 + h * 3_600_000 + mi * 60_000 + sec * 1_000 + ms;
+        Ok(Self {
+            text: s.to_string(),
+            unix_ms,
+        })
+    }
+
+    pub fn as_str(&self) -> &str {
+        &self.text
+    }
+
+    pub fn unix_ms(&self) -> i64 {
+        self.unix_ms
+    }
+
+    /// True when this instant is at or before `now`.
+    pub fn is_expired_at(&self, now: &Timestamp) -> bool {
+        self.unix_ms <= now.unix_ms
+    }
+}
+
+impl std::fmt::Display for Timestamp {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.write_str(&self.text)
+    }
+}
+
+impl std::fmt::Debug for Timestamp {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "Timestamp({})", self.text)
+    }
+}
+
+impl Serialize for Timestamp {
+    fn serialize<S: serde::Serializer>(&self, s: S) -> Result<S::Ok, S::Error> {
+        s.serialize_str(&self.text)
+    }
+}
+
+impl<'de> Deserialize<'de> for Timestamp {
+    fn deserialize<D: serde::Deserializer<'de>>(d: D) -> Result<Self, D::Error> {
+        let s = String::deserialize(d)?;
+        Timestamp::parse(&s).map_err(serde::de::Error::custom)
+    }
+}
+
+fn is_leap(y: i64) -> bool {
+    (y % 4 == 0 && y % 100 != 0) || y % 400 == 0
+}
+
+fn days_in_month(y: i64, m: i64) -> i64 {
+    match m {
+        1 | 3 | 5 | 7 | 8 | 10 | 12 => 31,
+        4 | 6 | 9 | 11 => 30,
+        2 if is_leap(y) => 29,
+        2 => 28,
+        _ => 0,
+    }
+}
+
+/// Days from 1970-01-01 to the given civil date (Howard Hinnant's
+/// `days_from_civil`, which is exact for the proleptic Gregorian calendar).
+fn days_from_civil(y: i64, m: i64, d: i64) -> i64 {
+    let y = if m <= 2 { y - 1 } else { y };
+    let era = if y >= 0 { y } else { y - 399 } / 400;
+    let yoe = y - era * 400;
+    let mp = (m + 9) % 12;
+    let doy = (153 * mp + 2) / 5 + d - 1;
+    let doe = yoe * 365 + yoe / 4 - yoe / 100 + doy;
+    era * 146_097 + doe - 719_468
+}
+
+/// Inverse of [`days_from_civil`].
+fn civil_from_days(z: i64) -> (i64, i64, i64) {
+    let z = z + 719_468;
+    let era = if z >= 0 { z } else { z - 146_096 } / 146_097;
+    let doe = z - era * 146_097;
+    let yoe = (doe - doe / 1460 + doe / 36524 - doe / 146_096) / 365;
+    let y = yoe + era * 400;
+    let doy = doe - (365 * yoe + yoe / 4 - yoe / 100);
+    let mp = (5 * doy + 2) / 153;
+    let d = doy - (153 * mp + 2) / 5 + 1;
+    let m = if mp < 10 { mp + 3 } else { mp - 9 };
+    (if m <= 2 { y + 1 } else { y }, m, d)
+}
+
+// ────────────────────────────────────────────────────────────────────────
+// Trust, settlement, validation
+// ────────────────────────────────────────────────────────────────────────
+
+/// Buyer-selectable provider trust requirement (v2 direction §13).
+///
+/// A scheduling constraint, not a network-wide identity policy: the
+/// network never refuses a `Community` provider, individual buyers do.
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
+#[serde(rename_all = "lowercase")]
+pub enum TrustTier {
+    /// Cryptographic identity only. No KYC, public reputation, low-value work.
+    /// The default: a fresh key with no history is exactly this.
+    #[default]
+    Community,
+    /// Established receipt history and a minimum success rate.
+    Standard,
+    /// Provider credential, plus hardware verification where available.
+    Verified,
+    /// Allowlisted provider set, encrypted inputs, restricted telemetry.
+    Private,
+    /// Organization verification, SLA, jurisdiction controls, audited pool.
+    Enterprise,
+}
+
+impl TrustTier {
+    /// Whether a provider at `self` satisfies a job asking for `required`.
+    ///
+    /// Ordering is by strength, so a Verified provider can take Standard
+    /// work. `Private` and `Enterprise` are *not* reachable by merely being
+    /// strong — they mean "on this buyer's list", so they only satisfy
+    /// themselves.
+    pub fn satisfies(self, required: TrustTier) -> bool {
+        match required {
+            TrustTier::Private | TrustTier::Enterprise => self == required,
+            _ => self >= required,
+        }
+    }
+}
+
+/// Which settlement implementation a job uses.
+///
+/// An open string rather than a closed enum: the protocol must not make
+/// adoption contingent on one payment product. CoinPay is the default and
+/// best-integrated adapter, not a requirement (v2 direction §8.3).
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(transparent)]
+pub struct SettlementAdapter(pub String);
+
+impl SettlementAdapter {
+    /// First-party: CoinPay DID escrow and multi-asset settlement.
+    pub const COINPAY: &'static str = "coinpay";
+    /// HTTP 402 pay-per-request.
+    pub const X402: &'static str = "x402";
+    /// Bitcoin Lightning.
+    pub const LIGHTNING: &'static str = "lightning";
+    /// Out-of-band invoicing; the receipt records terms, not a transfer.
+    pub const INVOICE: &'static str = "invoice";
+    /// Prepaid credits held by a managed gateway the buyer selected.
+    pub const GATEWAY_CREDITS: &'static str = "gateway-credits";
+    /// Internal accounting inside a private network (§24).
+    pub const PRIVATE: &'static str = "private";
+
+    pub fn coinpay() -> Self {
+        Self(Self::COINPAY.into())
+    }
+
+    pub fn as_str(&self) -> &str {
+        &self.0
+    }
+
+    pub fn validate(&self) -> Result<(), Error> {
+        if self.0.is_empty()
+            || !self
+                .0
+                .chars()
+                .all(|c| c.is_ascii_lowercase() || c.is_ascii_digit() || c == '-')
+        {
+            return Err(Error::Format(format!(
+                "settlement adapter {:?} must be lowercase kebab-case",
+                self.0
+            )));
+        }
+        Ok(())
+    }
+}
+
+/// How hard a result gets checked before it is accepted and paid for.
+///
+/// The levels map to v2 direction §12. They are a buyer's economic choice:
+/// duplicate execution costs roughly double, so a cheap image generation
+/// and a high-value deterministic transform should not pay the same
+/// verification tax.
+#[derive(Clone, Copy, Debug, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
+#[serde(rename_all = "kebab-case")]
+pub enum ValidationLevel {
+    /// L0 — the requester accepts whatever comes back.
+    Requester,
+    /// L1 — deterministic or schema validation the buyer can run alone.
+    Schema,
+    /// L2 — a sampled fraction runs on a second, independent provider.
+    Spotcheck,
+    /// L3 — run on N providers and compare.
+    Quorum,
+    /// L4 — hardware or runtime attestation.
+    Attested,
+    /// L5 — a workload-specific proof scheme.
+    Proof,
+}
+
+/// A job's full validation policy.
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct ValidationPolicy {
+    pub level: ValidationLevel,
+    /// How many independent providers execute the job. `1` is the normal
+    /// case; quorum validation needs at least 3 to break a tie.
+    #[serde(default = "one")]
+    pub redundancy: u32,
+    /// For `Spotcheck`: the percentage of jobs duplicated, 0-100.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub spotcheck_percent: Option<u32>,
+}
+
+fn one() -> u32 {
+    1
+}
+
+impl Default for ValidationPolicy {
+    fn default() -> Self {
+        Self {
+            level: ValidationLevel::Schema,
+            redundancy: 1,
+            spotcheck_percent: None,
+        }
+    }
+}
+
+impl ValidationPolicy {
+    pub fn validate(&self) -> Result<(), Error> {
+        if self.redundancy == 0 {
+            return Err(Error::Format(
+                "validation redundancy must be at least 1".into(),
+            ));
+        }
+        if self.level == ValidationLevel::Quorum && self.redundancy < 3 {
+            return Err(Error::Format(
+                "quorum validation needs redundancy of at least 3 to resolve a disagreement".into(),
+            ));
+        }
+        if let Some(pct) = self.spotcheck_percent {
+            if pct > 100 {
+                return Err(Error::Format(format!(
+                    "spotcheck percent {pct} must be 0-100"
+                )));
+            }
+            if self.level != ValidationLevel::Spotcheck {
+                return Err(Error::Format(
+                    "spotcheck_percent only applies to the spotcheck validation level".into(),
+                ));
+            }
+        }
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    // ── content hashes ──────────────────────────────────────────────────
+
+    #[test]
+    fn content_hash_round_trips() {
+        let h = ContentHash::of(b"hello c0mpute");
+        let parsed = ContentHash::parse(&h.to_wire()).unwrap();
+        assert_eq!(h, parsed);
+        assert_eq!(h.algorithm(), "blake3");
+    }
+
+    #[test]
+    fn content_hash_is_stable_for_the_same_bytes() {
+        assert_eq!(ContentHash::of(b"abc"), ContentHash::of(b"abc"));
+        assert_ne!(ContentHash::of(b"abc"), ContentHash::of(b"abd"));
+    }
+
+    #[test]
+    fn c0_uri_round_trips() {
+        let h = ContentHash::of(b"payload");
+        let uri = h.to_c0_uri();
+        assert!(uri.starts_with("c0://blake3:"));
+        assert_eq!(ContentHash::parse_uri(&uri).unwrap(), h);
+        assert_eq!(ContentHash::parse_uri(&h.to_wire()).unwrap(), h);
+    }
+
+    #[test]
+    fn content_hash_rejects_malformed_input() {
+        for bad in [
+            "deadbeef",
+            "blake3:",
+            "blake3:XYZ",
+            "blake3:abc",
+            ":abc",
+            "BLAKE3:ab",
+        ] {
+            assert!(ContentHash::parse(bad).is_err(), "{bad} should be rejected");
+        }
+    }
+
+    // ── money ───────────────────────────────────────────────────────────
+
+    #[test]
+    fn money_validates_plain_decimals() {
+        for ok in ["0", "0.042", "1", "12.5", "1000000.000001"] {
+            Money::new(ok, "USD").validate().unwrap();
+        }
+    }
+
+    #[test]
+    fn money_rejects_floats_dressed_as_strings() {
+        for bad in [
+            "", "1e5", "-1", "+1", "1.", ".5", "01", "1.2.3", "1,5", "abc",
+        ] {
+            assert!(
+                Money::new(bad, "USD").validate().is_err(),
+                "{bad:?} should be rejected"
+            );
+        }
+    }
+
+    #[test]
+    fn money_rejects_a_malformed_currency() {
+        assert!(Money::new("1", "usd").validate().is_err());
+        assert!(Money::new("1", "").validate().is_err());
+    }
+
+    #[test]
+    fn money_compares_by_value_not_string_length() {
+        let a = Money::new("0.10", "USD");
+        let b = Money::new("0.1", "USD");
+        assert_eq!(a.cmp_amount(&b).unwrap(), Ordering::Equal);
+
+        let cheap = Money::new("0.042", "USD");
+        let cap = Money::new("0.10", "USD");
+        // Lexically "0.042" > "0.10"; numerically it is not.
+        assert_eq!(cheap.cmp_amount(&cap).unwrap(), Ordering::Less);
+        assert!(cheap.is_within(&cap).unwrap());
+        assert!(!cap.is_within(&cheap).unwrap());
+    }
+
+    #[test]
+    fn money_compares_large_integer_parts() {
+        let a = Money::new("9", "USD");
+        let b = Money::new("10", "USD");
+        assert_eq!(a.cmp_amount(&b).unwrap(), Ordering::Less);
+    }
+
+    #[test]
+    fn money_refuses_cross_currency_comparison() {
+        let usd = Money::new("1", "USD");
+        let usdc = Money::new("1", "USDC");
+        assert!(usd.cmp_amount(&usdc).is_err());
+    }
+
+    // ── timestamps ──────────────────────────────────────────────────────
+
+    #[test]
+    fn timestamp_round_trips_through_unix_ms() {
+        let t = Timestamp::parse("2026-09-06T16:02:00.000Z").unwrap();
+        let again = Timestamp::from_unix_ms(t.unix_ms()).unwrap();
+        assert_eq!(t.as_str(), again.as_str());
+    }
+
+    #[test]
+    fn timestamp_epoch_is_zero() {
+        assert_eq!(
+            Timestamp::parse("1970-01-01T00:00:00.000Z")
+                .unwrap()
+                .unix_ms(),
+            0
+        );
+        assert_eq!(
+            Timestamp::from_unix_ms(0).unwrap().as_str(),
+            "1970-01-01T00:00:00.000Z"
+        );
+    }
+
+    #[test]
+    fn timestamp_handles_leap_days() {
+        let leap = Timestamp::parse("2024-02-29T12:00:00.000Z").unwrap();
+        assert_eq!(
+            Timestamp::from_unix_ms(leap.unix_ms()).unwrap().as_str(),
+            "2024-02-29T12:00:00.000Z"
+        );
+        // 2100 is not a leap year: century rule.
+        assert!(Timestamp::parse("2100-02-29T00:00:00.000Z").is_err());
+        assert!(Timestamp::parse("2000-02-29T00:00:00.000Z").is_ok());
+    }
+
+    #[test]
+    fn timestamp_rejects_every_other_spelling_of_the_same_instant() {
+        for bad in [
+            "2026-09-06T16:02:00Z",        // no milliseconds
+            "2026-09-06T16:02:00+00:00",   // offset instead of Z
+            "2026-09-06T16:02:00.000z",    // lowercase z
+            "2026-09-06 16:02:00.000Z",    // space separator
+            "2026-09-06T16:02:00.000000Z", // microseconds
+            "2026-13-06T16:02:00.000Z",    // month 13
+            "2026-09-31T16:02:00.000Z",    // September has 30 days
+            "2026-09-06T24:00:00.000Z",    // hour 24
+            "2026-09-06T16:60:00.000Z",    // minute 60
+        ] {
+            assert!(Timestamp::parse(bad).is_err(), "{bad:?} should be rejected");
+        }
+    }
+
+    #[test]
+    fn timestamp_orders_chronologically() {
+        let early = Timestamp::parse("2026-09-06T16:02:00.000Z").unwrap();
+        let late = Timestamp::parse("2026-09-06T16:02:00.001Z").unwrap();
+        assert!(early < late);
+        assert!(early.is_expired_at(&late));
+        assert!(!late.is_expired_at(&early));
+        assert!(early.is_expired_at(&early), "expiry is inclusive");
+    }
+
+    // ── trust ───────────────────────────────────────────────────────────
+
+    #[test]
+    fn stronger_tiers_satisfy_weaker_requirements() {
+        assert!(TrustTier::Verified.satisfies(TrustTier::Standard));
+        assert!(TrustTier::Standard.satisfies(TrustTier::Community));
+        assert!(!TrustTier::Community.satisfies(TrustTier::Standard));
+    }
+
+    #[test]
+    fn allowlist_tiers_only_satisfy_themselves() {
+        // Being "stronger" cannot buy your way onto an allowlist.
+        assert!(!TrustTier::Enterprise.satisfies(TrustTier::Private));
+        assert!(!TrustTier::Verified.satisfies(TrustTier::Enterprise));
+        assert!(TrustTier::Private.satisfies(TrustTier::Private));
+        assert!(TrustTier::Enterprise.satisfies(TrustTier::Enterprise));
+        // But they still clear the ordinary tiers.
+        assert!(TrustTier::Enterprise.satisfies(TrustTier::Standard));
+    }
+
+    #[test]
+    fn trust_tier_serializes_lowercase() {
+        assert_eq!(
+            serde_json::to_string(&TrustTier::Standard).unwrap(),
+            "\"standard\""
+        );
+    }
+
+    // ── settlement + validation ─────────────────────────────────────────
+
+    #[test]
+    fn settlement_adapter_is_an_open_string() {
+        SettlementAdapter::coinpay().validate().unwrap();
+        SettlementAdapter("some-future-rail".into())
+            .validate()
+            .unwrap();
+        assert!(SettlementAdapter("CoinPay".into()).validate().is_err());
+        assert!(SettlementAdapter(String::new()).validate().is_err());
+    }
+
+    #[test]
+    fn settlement_adapter_serializes_as_a_bare_string() {
+        assert_eq!(
+            serde_json::to_string(&SettlementAdapter::coinpay()).unwrap(),
+            "\"coinpay\""
+        );
+    }
+
+    #[test]
+    fn quorum_needs_enough_providers_to_break_a_tie() {
+        let mut p = ValidationPolicy {
+            level: ValidationLevel::Quorum,
+            redundancy: 2,
+            spotcheck_percent: None,
+        };
+        assert!(p.validate().is_err());
+        p.redundancy = 3;
+        p.validate().unwrap();
+    }
+
+    #[test]
+    fn validation_policy_rejects_nonsense() {
+        let zero = ValidationPolicy {
+            level: ValidationLevel::Schema,
+            redundancy: 0,
+            spotcheck_percent: None,
+        };
+        assert!(zero.validate().is_err());
+
+        let misplaced = ValidationPolicy {
+            level: ValidationLevel::Schema,
+            redundancy: 1,
+            spotcheck_percent: Some(10),
+        };
+        assert!(misplaced.validate().is_err());
+
+        let too_much = ValidationPolicy {
+            level: ValidationLevel::Spotcheck,
+            redundancy: 1,
+            spotcheck_percent: Some(101),
+        };
+        assert!(too_much.validate().is_err());
+    }
+}

--- a/node/crates/c0mpute-envelope/tests/vectors.rs
+++ b/node/crates/c0mpute-envelope/tests/vectors.rs
@@ -1,0 +1,373 @@
+//! Known-answer vectors for the c0mpute v2 wire format.
+//!
+//! Phase 1 of the v2 direction has an acceptance criterion that job, offer
+//! and receipt hashes reproduce *across implementations*. That is only
+//! checkable against fixed answers, so this file pins them: given these
+//! seeds and these payloads, an implementation must produce exactly these
+//! DIDs, these canonical bytes, and these hashes.
+//!
+//! A failure here is not a flaky test. It means the wire format changed,
+//! and every previously signed advert, offer and receipt on the network
+//! now hashes differently. If the change is deliberate, the payload's
+//! version identifier has to move with it.
+//!
+//! To regenerate the copies embedded in `docs/protocol/`:
+//!
+//! ```sh
+//! cargo test -p c0mpute-envelope --test vectors -- --nocapture print_vectors
+//! ```
+
+use c0mpute_envelope::advert::{CpuSpec, Disclosure, ProviderCapabilities, Rate};
+use c0mpute_envelope::job::{
+    Bound, Economics, Execution, GpuRequirement, Isolation, JobInput, WorkloadRef,
+};
+use c0mpute_envelope::receipt::{SettlementRecord, ValidationOutcome, ValidationStatus};
+use c0mpute_envelope::*;
+
+/// Fixed seeds. Never use these for anything real.
+const BUYER_SEED: [u8; 32] = [0x11; 32];
+const PROVIDER_SEED: [u8; 32] = [0x77; 32];
+
+const BUYER_DID: &str = "did:c0mpute:z6MktULudTtAsAhRegYPiZ6631RV3viv12qd4GQF8z1xB22S";
+const PROVIDER_DID: &str = "did:c0mpute:z6MkswFb62xmEDrqnknM3TP112AiH6A5YETp7gc2Qz4Wqkar";
+
+const ADVERT_HASH: &str = "blake3:cecfc7a08527ee50ab8945bb636afc940b5afff48a50cdfbcdee501edbebd2c2";
+const JOB_ID: &str = "blake3:4a4323c24e72bb676e575acb33051450e930e499b7b68d6a41ad7d47f5551b35";
+const OFFER_HASH: &str = "blake3:9e9151a1d682f3c60fb596b92dad5757be890f476cf979dbe8c924228494393f";
+const RECEIPT_HASH: &str =
+    "blake3:7c5ba273a840b6bfd859f24904e032229010cee3de67c4102e194d3c558e87df";
+const ACCEPTANCE_HASH: &str =
+    "blake3:8b5a7302ed135469555c185b0b7cbcb1ecc9266bfa0c88b25bf6f48f89f45b9a";
+
+fn ts(s: &str) -> Timestamp {
+    Timestamp::parse(s).unwrap()
+}
+
+fn buyer() -> SigningIdentity {
+    SigningIdentity::from_seed(&BUYER_SEED)
+}
+
+fn provider() -> SigningIdentity {
+    SigningIdentity::from_seed(&PROVIDER_SEED)
+}
+
+fn advert() -> ProviderAdvert {
+    ProviderAdvert {
+        sequence: 8472,
+        issued_at: ts("2026-09-06T23:50:00.000Z"),
+        expires_at: ts("2026-09-06T23:59:00.000Z"),
+        capabilities: ProviderCapabilities {
+            cpu: CpuSpec {
+                arch: "x86_64".into(),
+                cores: 32,
+            },
+            memory_gib: 128,
+            gpus: vec![GpuSpec {
+                vendor: "nvidia".into(),
+                family: Some("ada".into()),
+                vram_gib: 24,
+                features: vec!["cuda".into(), "nvenc".into()],
+                count: 1,
+            }],
+            storage_gib: 1200,
+            bandwidth_mbps: 1000,
+            workloads: vec!["infernet.inference".into(), "transcode.ffmpeg".into()],
+        },
+        pricing: vec![Rate {
+            workload: "infernet.inference".into(),
+            unit: "1m-output-tokens".into(),
+            price: Money::new("0.60", "USD"),
+        }],
+        trust: ProviderTrust {
+            tier: TrustTier::Standard,
+            credentials: vec![],
+        },
+        disclosure: Some(Disclosure {
+            region: Some("us-west".into()),
+            country: None,
+            asn: None,
+        }),
+    }
+}
+
+fn job() -> JobManifest {
+    JobManifest {
+        workload: WorkloadRef {
+            type_id: "infernet.inference".into(),
+            version: Some(">=1 <2".into()),
+        },
+        requester: buyer().did().clone(),
+        requirements: Requirements {
+            gpu: Some(GpuRequirement {
+                count: 1,
+                vram_gib: Some(Bound::at_least(24)),
+                features: vec!["cuda".into()],
+            }),
+            cpu_cores: None,
+            memory_gib: Some(Bound::at_least(32)),
+            region: vec!["us-west".into()],
+            trust_tier: TrustTier::Standard,
+            providers: vec![],
+        },
+        input: Some(JobInput {
+            reference: ContentHash::of(b"prompts.jsonl"),
+            encryption: Some("recipient-selected".into()),
+            bytes: Some(4096),
+        }),
+        execution: Execution {
+            timeout_seconds: 120,
+            retry: 2,
+            isolation: Isolation::Container,
+            runtime_digest: Some(ContentHash::of(b"runtime image")),
+            network: false,
+        },
+        economics: Economics {
+            max_price: Money::new("0.10", "USD"),
+            settlement: SettlementAdapter::coinpay(),
+            escrow: true,
+        },
+        validation: ValidationPolicy {
+            level: ValidationLevel::Spotcheck,
+            redundancy: 1,
+            spotcheck_percent: Some(5),
+        },
+        output: JobOutput {
+            retention_seconds: 3600,
+            max_bytes: 10_485_760,
+        },
+        announced_at: ts("2026-09-06T16:00:00.000Z"),
+        deadline: ts("2026-09-06T16:10:00.000Z"),
+    }
+}
+
+fn offer(job_id: ContentHash, advert_hash: ContentHash) -> Offer {
+    Offer {
+        job: job_id,
+        price: Money::new("0.042", "USD"),
+        expected_duration_ms: 12_000,
+        start_before: ts("2026-09-06T16:02:00.000Z"),
+        expires_at: ts("2026-09-06T16:00:10.000Z"),
+        capability_advert: Some(advert_hash),
+        coordinator: false,
+    }
+}
+
+fn receipt(job_id: ContentHash, offer_hash: ContentHash) -> Receipt {
+    Receipt {
+        job: job_id,
+        buyer: buyer().did().clone(),
+        provider: provider().did().clone(),
+        validator: None,
+        workload: "infernet.inference".into(),
+        offer: offer_hash,
+        input_hash: Some(ContentHash::of(b"prompts.jsonl")),
+        output_hash: Some(ContentHash::of(b"completions.jsonl")),
+        runtime_hash: Some(ContentHash::of(b"runtime image")),
+        started_at: ts("2026-09-06T16:01:00.000Z"),
+        completed_at: ts("2026-09-06T16:01:12.000Z"),
+        price: Money::new("0.042", "USD"),
+        validation: ValidationOutcome {
+            policy: ValidationPolicy {
+                level: ValidationLevel::Spotcheck,
+                redundancy: 1,
+                spotcheck_percent: Some(5),
+            },
+            status: ValidationStatus::Accepted,
+            detail: None,
+        },
+        settlement: SettlementRecord {
+            adapter: SettlementAdapter::coinpay(),
+            reference: Some("cp_rcpt_01J8Z3".into()),
+            settled: true,
+        },
+    }
+}
+
+// ────────────────────────────────────────────────────────────────────────
+// Pinned answers
+// ────────────────────────────────────────────────────────────────────────
+
+#[test]
+fn identities_derive_from_seeds() {
+    assert_eq!(buyer().did().as_str(), BUYER_DID);
+    assert_eq!(provider().did().as_str(), PROVIDER_DID);
+}
+
+#[test]
+fn advert_hash_is_pinned() {
+    let env = Envelope::seal(&provider(), advert()).unwrap();
+    env.open().unwrap();
+    assert_eq!(env.content_hash().unwrap().to_wire(), ADVERT_HASH);
+}
+
+#[test]
+fn job_id_is_pinned() {
+    assert_eq!(job().id().unwrap().to_wire(), JOB_ID);
+}
+
+#[test]
+fn offer_hash_is_pinned() {
+    let advert_env = Envelope::seal(&provider(), advert()).unwrap();
+    let j = job();
+    let o = offer(j.id().unwrap(), advert_env.content_hash().unwrap());
+    o.check_against(&j).unwrap();
+    let env = Envelope::seal(&provider(), o).unwrap();
+    assert_eq!(env.content_hash().unwrap().to_wire(), OFFER_HASH);
+}
+
+#[test]
+fn receipt_and_acceptance_hashes_are_pinned() {
+    let offer_hash = ContentHash::parse(OFFER_HASH).unwrap();
+    let receipt_env =
+        Envelope::seal(&provider(), receipt(job().id().unwrap(), offer_hash)).unwrap();
+    assert_eq!(receipt_env.content_hash().unwrap().to_wire(), RECEIPT_HASH);
+
+    let acceptance_env = Envelope::seal(
+        &buyer(),
+        ReceiptAcceptance {
+            receipt: receipt_env.content_hash().unwrap(),
+            accepted: true,
+            signed_at: ts("2026-09-06T16:01:20.000Z"),
+            reason: None,
+        },
+    )
+    .unwrap();
+    assert_eq!(
+        acceptance_env.content_hash().unwrap().to_wire(),
+        ACCEPTANCE_HASH
+    );
+}
+
+/// The whole chain, as a buyer and a provider actually walk it: advert,
+/// job, offer against that job, receipt citing that offer, buyer
+/// countersignature citing that receipt. Every link is a content hash, so
+/// no participant has to be trusted to report the previous step honestly.
+#[test]
+fn the_full_chain_verifies_end_to_end() {
+    let advert_env = Envelope::seal(&provider(), advert()).unwrap();
+    let job_env = Envelope::seal(&buyer(), job()).unwrap();
+    let j = job_env.open().unwrap();
+    assert!(j.signed_by(&job_env.signer));
+
+    let offer_env = Envelope::seal(
+        &provider(),
+        offer(j.id().unwrap(), advert_env.content_hash().unwrap()),
+    )
+    .unwrap();
+    let o = offer_env.open().unwrap();
+    o.check_against(j).unwrap();
+    assert_eq!(
+        o.capability_advert.as_ref().unwrap(),
+        &advert_env.content_hash().unwrap()
+    );
+
+    let receipt_env = Envelope::seal(
+        &provider(),
+        receipt(j.id().unwrap(), offer_env.content_hash().unwrap()),
+    )
+    .unwrap();
+    let r = receipt_env.open().unwrap();
+    assert!(r.is_success());
+    assert_eq!(r.job, j.id().unwrap());
+    assert_eq!(r.offer, offer_env.content_hash().unwrap());
+    // The price paid is the price that was signed for, not an assertion.
+    assert_eq!(r.price, o.price);
+
+    let acceptance_env = Envelope::seal(
+        &buyer(),
+        ReceiptAcceptance {
+            receipt: receipt_env.content_hash().unwrap(),
+            accepted: true,
+            signed_at: ts("2026-09-06T16:01:20.000Z"),
+            reason: None,
+        },
+    )
+    .unwrap();
+    let a = acceptance_env.open().unwrap();
+    assert_eq!(a.receipt, receipt_env.content_hash().unwrap());
+    assert_eq!(acceptance_env.signer.as_str(), BUYER_DID);
+}
+
+/// Nothing in the chain needs an index, a database, or a hosted endpoint
+/// to be believed: a third party holding only the JSON can check it all.
+#[test]
+fn a_third_party_can_verify_from_json_alone() {
+    let advert_json = Envelope::seal(&provider(), advert())
+        .unwrap()
+        .to_canonical_json()
+        .unwrap();
+    let job_json = Envelope::seal(&buyer(), job())
+        .unwrap()
+        .to_canonical_json()
+        .unwrap();
+
+    // Reconstructed from text, by someone who saw none of it happen.
+    let advert_env: Envelope<ProviderAdvert> = Envelope::from_json(&advert_json).unwrap();
+    let job_env: Envelope<JobManifest> = Envelope::from_json(&job_json).unwrap();
+
+    assert_eq!(advert_env.signer.as_str(), PROVIDER_DID);
+    assert!(advert_env.open().unwrap().runs("infernet.inference"));
+    assert_eq!(job_env.open().unwrap().id().unwrap().to_wire(), JOB_ID);
+}
+
+/// Prints the vectors for `docs/protocol/`. Not an assertion — run it with
+/// `--nocapture` when the documented examples need refreshing.
+#[test]
+fn print_vectors() {
+    let advert_env = Envelope::seal(&provider(), advert()).unwrap();
+    let j = job();
+    let job_env = Envelope::seal(&buyer(), j.clone()).unwrap();
+    let offer_env = Envelope::seal(
+        &provider(),
+        offer(j.id().unwrap(), advert_env.content_hash().unwrap()),
+    )
+    .unwrap();
+    let receipt_env = Envelope::seal(
+        &provider(),
+        receipt(j.id().unwrap(), offer_env.content_hash().unwrap()),
+    )
+    .unwrap();
+    let acceptance_env = Envelope::seal(
+        &buyer(),
+        ReceiptAcceptance {
+            receipt: receipt_env.content_hash().unwrap(),
+            accepted: true,
+            signed_at: ts("2026-09-06T16:01:20.000Z"),
+            reason: None,
+        },
+    )
+    .unwrap();
+
+    println!("\nbuyer    {}", buyer().did());
+    println!("provider {}\n", provider().did());
+    println!("job id {}\n", j.id().unwrap());
+    for (label, json, hash) in [
+        (
+            "provider.advert/v1",
+            advert_env.to_canonical_json().unwrap(),
+            advert_env.content_hash().unwrap(),
+        ),
+        (
+            "job/v2",
+            job_env.to_canonical_json().unwrap(),
+            job_env.content_hash().unwrap(),
+        ),
+        (
+            "offer/v1",
+            offer_env.to_canonical_json().unwrap(),
+            offer_env.content_hash().unwrap(),
+        ),
+        (
+            "receipt/v1",
+            receipt_env.to_canonical_json().unwrap(),
+            receipt_env.content_hash().unwrap(),
+        ),
+        (
+            "receipt.acceptance/v1",
+            acceptance_env.to_canonical_json().unwrap(),
+            acceptance_env.content_hash().unwrap(),
+        ),
+    ] {
+        println!("## {label}\n\n{json}\n\nenvelope hash: {hash}\n");
+    }
+}

--- a/scripts/check-protocol-docs.py
+++ b/scripts/check-protocol-docs.py
@@ -1,0 +1,176 @@
+#!/usr/bin/env python3
+"""Check that the JSON examples in docs/protocol/ match the implementation.
+
+Every full envelope shown in `docs/protocol/*.md` is canonicalized here, in
+Python, and compared byte-for-byte against what `c0mpute-envelope` produced
+for the same record. That makes this two checks in one:
+
+1. **The docs are not fiction.** A field renamed in Rust without updating
+   the spec page fails here, on the commit that does it.
+
+2. **Canonicalization is genuinely portable.** Python's
+   `json.dumps(sort_keys=True, separators=(",", ":"))` is the naive
+   implementation the spec claims to be compatible with (see
+   docs/protocol/canonical-json.md). If the Rust canonicalizer ever drifts
+   into something a second implementation would not reproduce, the two
+   stop agreeing here.
+
+The second is the one worth having. c0mpute's Phase 1 acceptance criterion
+is that job, offer and receipt hashes reproduce *across implementations*,
+and a claim like that is only worth what it is tested against.
+
+Usage:
+    scripts/check-protocol-docs.py            # runs cargo itself
+    scripts/check-protocol-docs.py --vectors <file>
+"""
+
+from __future__ import annotations
+
+import argparse
+import glob
+import json
+import os
+import re
+import subprocess
+import sys
+
+REPO = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+DOCS_GLOB = os.path.join(REPO, "docs", "protocol", "*.md")
+VECTOR_CMD = [
+    "cargo", "test", "-q", "-p", "c0mpute-envelope",
+    "--test", "vectors", "--", "--nocapture", "print_vectors",
+]
+
+
+def canonicalize(obj) -> str:
+    """The canonical JSON of docs/protocol/canonical-json.md.
+
+    Sorted keys, no whitespace, UTF-8 values. Floats are rejected before we
+    get here, so the one genuinely hard part of RFC 8785 never applies.
+    """
+    return json.dumps(obj, sort_keys=True, separators=(",", ":"), ensure_ascii=False)
+
+
+def find_float(obj, path="$"):
+    """Return the path of the first float, or None. Floats cannot be signed."""
+    if isinstance(obj, float):
+        return path
+    if isinstance(obj, dict):
+        for k, v in obj.items():
+            if (hit := find_float(v, f"{path}.{k}")):
+                return hit
+    if isinstance(obj, list):
+        for i, v in enumerate(obj):
+            if (hit := find_float(v, f"{path}[{i}]")):
+                return hit
+    return None
+
+
+def load_vectors(text: str) -> dict[str, str]:
+    """The canonical envelopes the Rust implementation printed."""
+    out = {}
+    for line in text.splitlines():
+        line = line.strip()
+        if not line.startswith('{"payload"'):
+            continue
+        try:
+            obj = json.loads(line)
+        except json.JSONDecodeError:
+            continue
+        if isinstance(obj, dict) and "type" in obj:
+            out[obj["type"]] = line
+    return out
+
+
+def is_full_envelope(obj) -> bool:
+    """Distinguish a complete signed envelope from an illustrative snippet.
+
+    Pages legitimately show fragments (a `price` object on its own) and one
+    field-shape skeleton with an empty payload. Neither has anything to
+    compare against; only a populated, signed envelope does.
+    """
+    return (
+        isinstance(obj, dict)
+        and {"v", "type", "signer", "payload", "sig"} <= obj.keys()
+        and obj["payload"] != {}
+    )
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--vectors", help="file of printed vectors; runs cargo if omitted")
+    args = ap.parse_args()
+
+    if args.vectors:
+        vector_text = open(args.vectors, encoding="utf-8").read()
+    else:
+        print(f"$ {' '.join(VECTOR_CMD)}")
+        result = subprocess.run(VECTOR_CMD, cwd=REPO, capture_output=True, text=True)
+        if result.returncode != 0:
+            print("could not generate vectors:\n" + result.stdout + result.stderr)
+            return 2
+        vector_text = result.stdout
+
+    vectors = load_vectors(vector_text)
+    if not vectors:
+        print("no vectors found — did tests/vectors.rs stop printing?")
+        return 2
+    print(f"{len(vectors)} envelope types from c0mpute-envelope\n")
+
+    checked = skipped = failed = 0
+
+    for path in sorted(glob.glob(DOCS_GLOB)):
+        name = os.path.basename(path)
+        blocks = re.findall(r"```json\n(.*?)\n```", open(path, encoding="utf-8").read(), re.S)
+        for block in blocks:
+            try:
+                obj = json.loads(block)
+            except json.JSONDecodeError:
+                skipped += 1  # an inline fragment, not a document
+                continue
+            if not is_full_envelope(obj):
+                skipped += 1
+                continue
+
+            checked += 1
+            type_id = obj["type"]
+
+            if (where := find_float(obj)):
+                print(f"FAIL {name}: {type_id} has a float at {where}, which cannot be signed")
+                failed += 1
+                continue
+
+            if type_id not in vectors:
+                print(f"FAIL {name}: {type_id} has no vector in tests/vectors.rs to check against")
+                failed += 1
+                continue
+
+            mine, theirs = canonicalize(obj), vectors[type_id]
+            if mine != theirs:
+                print(f"FAIL {name}: {type_id} does not match the implementation")
+                for i, (a, b) in enumerate(zip(mine, theirs)):
+                    if a != b:
+                        lo = max(0, i - 50)
+                        print(f"      first difference at byte {i}")
+                        print(f"      docs: …{mine[lo:i + 50]}…")
+                        print(f"      impl: …{theirs[lo:i + 50]}…")
+                        break
+                else:
+                    print(f"      identical prefix; lengths {len(mine)} vs {len(theirs)}")
+                failed += 1
+                continue
+
+            print(f"ok   {name}: {type_id}")
+
+    print(f"\n{checked} envelope examples checked, {skipped} fragments skipped, {failed} failed")
+    if failed:
+        print(
+            "\nEither the docs are stale, or the wire format changed. If the format "
+            "change was deliberate, the payload's version identifier has to move with "
+            "it — see dips/v2.x/0025-signed-envelopes-and-native-identity.md."
+        )
+    return 1 if failed else 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
Implements the protocol spine of the [c0mpute v2 direction PRD](https://github.com/profullstack/c0mpute) — backlog items 2–8 — so that the P2P market built in Phase 2 has typed, verifiable records to carry.

## The gap this closes

The v1 market types in `c0mpute-net::topics` (`CapabilityAd`, `JobOffer`, `JobBid`, `JobAccept`, `JobReceipt`) carry **no signatures of their own**. Their comment says so: *"Signed by the worker's CoinPay DID once that lands; today we rely on gossipsub message authenticity."*

That is sufficient for exactly as long as a message is on the wire, and useless everywhere else:

- an advert **relayed by an indexer** arrives with no provenance
- a receipt **read back off disk** after a restart cannot be checked
- an offer **forwarded by a gateway** is the gateway's word
- a record shown to **a third party** who was never a peer is unverifiable

Reputation computed from unverifiable receipts has to be *believed*, which means a trusted database ends up in the middle of a network designed not to need one. DIP-0011 already deleted the coordinator; this makes the property hold at the record layer too.

## What's here

New crate `c0mpute-envelope`:

| | |
|---|---|
| **canonical JSON** | RFC 8785, minus floats and non-ASCII object keys. Both restrictions are *checked*, so a payload that would hash differently elsewhere fails at signing rather than on someone else's verification. |
| **identity** | `did:c0mpute:z…`, byte-compatible with `did:key` for ed25519, derived from the key libp2p already persists. Generated locally, offline, with no account and no payment product. |
| **envelopes** | Detached signature over domain-separated canonical bytes. A signature from one message type cannot be replayed as another — including between two types with identical field shapes, which is a test. |
| **payload types** | `provider.advert/v1`, `job/v2`, `offer/v1`, `receipt/v1`, and `receipt.acceptance/v1` for the buyer's countersignature. |

The crate depends on no transport, no HTTP client and no settlement product — identity enters as raw ed25519 bytes, settlement is an open string. That is what makes DIP-0024's dependency rule checkable rather than aspirational.

## Two deliberate deviations from the direction PRD

Both argued in DIP-0025:

1. **BLAKE3, not sha256.** The repo already content-addresses chunks with BLAKE3 (`c0mpute-proto::Hash`, `c0mpute://blake3:`). Running two hash trees over the same bytes would be a permanent tax for no gain. The algorithm is on the wire, so it is a default rather than a lock-in.
2. **A job's id is the hash of its whole canonical manifest**, not an `id` field inside it. The PRD's shape obliges every implementation to agree on which fields to strip before hashing; deriving it from the whole document deletes the step and the bugs that live in it.

## Verification

- **111 tests pass** — 102 unit, 8 pinned cross-implementation vectors, 1 doctest. Full workspace green.
- `cargo clippy -p c0mpute-envelope --all-targets -- -D warnings` clean; `cargo fmt --check` clean.
- **`scripts/check-protocol-docs.py`** re-canonicalizes every envelope shown in `docs/protocol/` using Python's `json.dumps(sort_keys=True)` and compares byte-for-byte against the Rust output. All five match.

That last one is two checks in one. It stops the spec pages going stale, and — the reason it earns a CI slot — it demonstrates the canonical form is reproducible by a **second implementation in another language**, which is Phase 1's actual acceptance criterion rather than a claim. Wired into CI as a *blocking* step: it has no legacy debt, so it starts green and stays there.

## Docs

- `docs/protocol/` — 8 pages carrying **real verified vectors**, not illustrative JSON. Pages for parts that don't exist yet (discovery, scheduling, relays, settlement, reputation) are deliberately **not** stubbed; the README lists them as unwritten so nothing in that directory describes code that hasn't been built.
- **DIP-0024** — protocol vs optional hosted services, naming `--gateway none` as the release gate that makes "you don't need us" true rather than asserted. Draft until that test exists.
- **DIP-0025** — this implementation.
- **DIP-0007 amended in place.** Its *identity* claim no longer holds; its payment, escrow and reputation half stands. CoinPay remains the default settlement adapter and the first-party integration — it is simply no longer load-bearing for the network to run. Anyone reading 0007 alone would otherwise implement the wrong thing.
- `docs/c0mpute-v1.md` marked superseded where it conflicts.

## Also

Backfills six v1.x DIPs (0018–0023) that had landed on disk without reaching the index.

## Not in this PR

The daemon, DHT discovery, gossip topics, buyer-side scheduling policy, relay/NAT paths, settlement adapters and reputation scoring — backlog items 9+. This PR is the layer they all need first. The v1 types in `c0mpute-net::topics` are untouched and keep working; Phase 2 ports the market onto the new types and retires them.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014YtSUWwT16LpvXoTyxeBGe
