### PR TITLE
feat(market): buyer-side scheduling, provider directory, and derived reputation

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -599,6 +599,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "c0mpute-market"
+version = "0.2.26"
+dependencies = [
+ "c0mpute-envelope",
+ "serde",
+ "serde_json",
+ "thiserror 2.0.18",
+]
+
+[[package]]
 name = "c0mpute-net"
 version = "0.2.26"
 dependencies = [

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,6 +15,7 @@ members = [
     "node/crates/c0mpute-doctor",
     "node/crates/c0mpute-proto",
     "node/crates/c0mpute-envelope",  # canonical serialization + signed protocol envelopes (DIP-0024)
+    "node/crates/c0mpute-market",    # provider directory, offer book, reputation, buyer-side selection
     "node/crates/c0mpute-api",
     "node/crates/c0mpute-transcode",    # in-process transcode workload (FFmpeg)
     "node/crates/c0mpute-secure-chat",  # in-process E2E encrypted p2p messaging (DIP-0018)
@@ -68,6 +69,7 @@ rpassword = "7"
 
 c0mpute-proto = { path = "node/crates/c0mpute-proto" }
 c0mpute-envelope = { path = "node/crates/c0mpute-envelope" }
+c0mpute-market = { path = "node/crates/c0mpute-market" }
 c0mpute-store = { path = "node/crates/c0mpute-store" }
 c0mpute-placement = { path = "node/crates/c0mpute-placement" }
 c0mpute-net = { path = "node/crates/c0mpute-net" }

--- a/apps/web/src/app/protocol/page.tsx
+++ b/apps/web/src/app/protocol/page.tsx
@@ -244,9 +244,9 @@ $ c0mpute run job.json --gateway none      # prove it works without us`}</CodeBl
         </p>
         <table className="w-full text-left border-collapse text-xs">
           <tbody className="divide-y divide-[var(--color-rule)]">
-            <Row k="shipped" v="canonical serialization, native identity, signed envelopes, the four message types, cross-implementation test vectors" />
-            <Row k="in progress" v="local daemon, DHT discovery, gossip job announcements, offer collection, buyer-side scheduling, relay paths for providers behind NAT" />
-            <Row k="planned" v="settlement adapters, receipt-derived reputation, generic container workloads, private network overlays" />
+            <Row k="shipped" v="canonical serialization, native identity, signed envelopes, the four message types, cross-implementation test vectors, provider directory, offer book, buyer-side selection policies, receipt-derived reputation" />
+            <Row k="in progress" v="the transport: local daemon, DHT discovery, gossip job announcements, offer collection over the wire, relay paths for providers behind NAT" />
+            <Row k="planned" v="settlement adapters, generic container workloads, private network overlays" />
           </tbody>
         </table>
         <p>

--- a/docs/protocol/README.md
+++ b/docs/protocol/README.md
@@ -1,10 +1,13 @@
 # The c0mpute protocol
 
-**Status:** Phase 1. Envelopes, identity and the four message types are
-specified and implemented. Discovery, scheduling, relays, settlement
-adapters and reputation are named here but not yet written — the pages
-that do not exist yet are listed at the bottom rather than stubbed, so
-nothing in this directory describes code that has not been built.
+**Status:** Phase 1 complete, Phase 2 in progress. Envelopes, identity,
+the four message types, buyer-side scheduling and receipt-derived
+reputation are specified and implemented. The **transport** is not:
+nothing yet carries adverts and offers between machines. Discovery,
+relays, settlement adapters and the validation tiers are named here but
+not yet written — the pages that do not exist yet are listed at the bottom
+rather than stubbed, so nothing in this directory describes code that has
+not been built.
 
 > c0mpute.com infrastructure is not required for the c0mpute network to
 > operate.
@@ -77,16 +80,23 @@ from a provider that claimed the capabilities relied on.
 | [jobs.md](jobs.md) | `job/v2` |
 | [offers.md](offers.md) | `offer/v1` |
 | [receipts.md](receipts.md) | `receipt/v1`, acceptance, and derived reputation |
+| [scheduling.md](scheduling.md) | eligibility, offer selection, and reputation scoring |
 
 ## Implementation
 
-`node/crates/c0mpute-envelope` is the reference implementation. It depends
-on no transport, no HTTP client and no settlement product — identity
-enters as raw ed25519 bytes and settlement is named by an open string.
-That is what makes DIP-0024's dependency rule checkable rather than
-aspirational.
+`node/crates/c0mpute-envelope` is the reference implementation of the
+message types; `node/crates/c0mpute-market` is the reference
+implementation of the buyer side — provider directory, offer book,
+reputation ledger and selection.
 
-Cross-implementation test vectors are pinned in that crate's
+Neither depends on a transport, an HTTP client or a settlement product.
+Identity enters as raw ed25519 bytes, settlement is named by an open
+string, and time enters as a parameter rather than being read from the
+clock. That is what makes DIP-0024's dependency rule checkable rather than
+aspirational — and what makes every expiry path testable rather than a
+matter of waiting.
+
+Cross-implementation test vectors are pinned in `c0mpute-envelope`'s
 `tests/vectors.rs`. A second implementation is correct when it reproduces
 those DIDs and hashes exactly. To print them:
 
@@ -94,19 +104,27 @@ those DIDs and hashes exactly. To print them:
 cargo test -p c0mpute-envelope --test vectors -- --nocapture print_vectors
 ```
 
+The full chain — advert, job, offer, selection, receipt, countersignature
+— runs end to end with no shared state between the parties in
+`c0mpute-market`'s `tests/gateway_none.rs`, which also covers what a
+hostile intermediary can and cannot do.
+
 ## Not yet written
 
 These are real parts of the v2 direction with no specification here,
 because there is no implementation to specify:
 
 - **discovery** — DHT provider lookup and gossip topic layout (Phase 2)
-- **scheduling** — buyer-side offer scoring policies (Phase 2)
 - **relays** — NAT traversal and outbound-only providers (Phase 2)
 - **settlement** — what a settlement adapter must do (Phase 3)
-- **reputation** — deriving scores from receipts (Phase 3)
 - **validation** — the L0–L5 tiers as a wire contract (Phase 3)
 
 `ValidationPolicy` and `SettlementAdapter` already travel in `job/v2` and
 `receipt/v1`, so a job can *state* its validation level and settlement
 rail today. What an implementation must do to honour either is the part
 still missing.
+
+Scheduling and receipt-derived reputation moved off this list with
+`c0mpute-market` — see [scheduling.md](scheduling.md). What is still
+missing there is the **transport**: the market logic runs, and nothing yet
+carries adverts and offers between machines.

--- a/docs/protocol/scheduling.md
+++ b/docs/protocol/scheduling.md
@@ -1,0 +1,188 @@
+# Scheduling
+
+**Reference implementation**, not a protocol requirement.
+
+This page describes how *our* client picks a winner. Another
+implementation may weigh offers completely differently and still be a
+correct c0mpute node — that is the point. What the protocol fixes is that
+**somebody on the buyer's side decides**, and that whoever decides can
+prove afterwards why.
+
+There is no globally authoritative matcher. The decision is made by one
+of:
+
+- the buyer's local client;
+- a managed gateway the buyer explicitly delegated to;
+- a private organization scheduler on a private overlay.
+
+## Eligibility is not scoring
+
+Two different questions, deliberately separated:
+
+| | |
+|---|---|
+| **Eligibility** | a hard filter. Failing it is disqualifying, not merely unattractive. |
+| **Scoring** | a preference. Reasonable buyers disagree, and all of them are right. |
+
+An implementation that gets scoring "wrong" makes bad purchases. An
+implementation that gets eligibility wrong pays for work that cannot
+happen. Only the second is a correctness bug, so only the second is
+specified tightly.
+
+### The eligibility gates
+
+A provider must clear all of these before its price is ever looked at:
+
+1. **Advert verifies and is unexpired.** Signature checks out and
+   `expiresAt` has not passed.
+2. **Workload offered.** The provider advertises this job's workload
+   namespace.
+3. **Allowlist.** If the job carries one, the provider is on it. Checked
+   *before* the trust tier — "one of these identities" is a stronger
+   statement than any tier a provider can claim for itself.
+4. **Trust tier.** The provider's claimed tier satisfies the job's.
+5. **Region.** If the job constrains region, the provider disclosed one
+   and it matches. An undisclosed region never matches a constraint.
+6. **Hardware.** GPU count, VRAM, GPU features, CPU cores, memory.
+7. **Offer validity.** Right job, within `maxPrice`, and able to finish
+   before `deadline`.
+
+**VRAM does not sum across cards.** Two 12 GiB GPUs do not satisfy a
+24 GiB requirement, because a model that does not fit on one card does not
+fit on two by addition. Counts *do* sum, across cards that each
+individually meet the spec.
+
+**Price is compared exactly**, as decimal-string arithmetic. Lexically
+`"0.042"` sorts above `"0.10"`, and `"0.9"` sorts below it — a string
+comparison rejects good offers and accepts ones that blow the cap.
+Floating point appears only in scoring, where a rounding error changes a
+preference rather than a correctness check.
+
+### Explaining an empty market
+
+"No providers found" is the most common thing a buyer sees on a young
+network, and it is useless on its own. Eligibility checks return *every*
+failed requirement rather than the first, so a client can say which
+constraint is actually binding — nobody has 24 GiB of VRAM, or six
+providers do but none disclosed a region — instead of making the buyer
+relax constraints one at a time.
+
+## One offer per provider
+
+The offer book keeps a provider's **best** offer, not its most recent:
+cheaper wins, then faster, then lower offer hash.
+
+Keeping the best rather than the latest makes the book independent of
+arrival order, so two buyers who heard the same offers in different
+sequences select the same winner. A provider improving its quote is
+legitimate; a provider *worsening* it after the fact should not be able to
+withdraw the better price it already signed.
+
+## Policies
+
+```bash
+c0mpute run job.json --policy cheapest
+c0mpute run job.json --policy fastest
+c0mpute run job.json --policy balanced   # default
+c0mpute run job.json --policy trusted
+c0mpute run job.json --policy private
+```
+
+Weights over four dimensions, each normalized to `0.0..=1.0`:
+
+| policy | price | speed | reputation | trust |
+|---|---|---|---|---|
+| `cheapest` | 1.0 | — | — | — |
+| `balanced` *(default)* | 0.4 | 0.2 | 0.4 | — |
+| `fastest` | — | 1.0 | — | — |
+| `trusted` | 0.2 | — | 0.5 | 0.3 |
+| `private` | 0.2 | — | 0.3 | 0.5 |
+
+`private` additionally **requires** the job to carry a provider
+allowlist. Without one, "private" would be a preference rather than a
+guarantee, and a caller asking for it almost certainly meant otherwise.
+
+### Why `balanced` is the default
+
+Pure lowest-bid selection is how a market races to the bottom. The
+cheapest quote often comes from the provider most likely to vanish
+mid-job, and the buyer pays for that in retries and missed deadlines.
+Pricing reputation alongside money means a provider that finishes what it
+starts can charge slightly more and still win, which is the incentive the
+network wants to create.
+
+### Proportional scoring, not min–max
+
+Lower-is-better dimensions score as `best / value`, **not** as min–max
+normalization across the candidate set.
+
+Min–max stretches whatever spread happens to be present across the full
+range, so with two offers a one-cent gap and a hundred-dollar gap both
+produce a 0.0-versus-1.0 split. Any price difference, however trivial,
+then dominates every other dimension — a provider that fails most of its
+jobs wins on being a cent cheaper, which is precisely what `balanced`
+exists to prevent.
+
+A ratio is proportional and scale-invariant: an offer 20% dearer than the
+best scores 0.83, whether the amounts are cents or thousands.
+
+### Determinism
+
+Two nodes running the **same** policy over the **same** offers must reach
+the same answer. So:
+
+- eligible providers and live offers are returned in DID order, never
+  hash-map order;
+- ties in score break by provider DID;
+- the offer book's best-offer rule removes arrival-order sensitivity.
+
+Two nodes running *different* policies reaching different answers is not a
+bug. It is the design.
+
+## Reputation
+
+Derived locally from signed receipts — see
+[receipts.md](receipts.md#deriving-reputation). Three properties that
+matter to scheduling:
+
+**A new provider is not a bad provider.** Success rate is smoothed toward
+a neutral prior (Laplace, one imaginary success and one imaginary
+failure), so an unknown provider scores exactly 0.5. Raw rates would make
+a provider's first job either unwinnable at 0/0, or make a fresh key with
+one success outrank a provider with a thousand jobs and two failures.
+
+**Failures count, which is why they are signed.** A network that only
+signs successes has a reputation system that measures nothing. A disputed
+job costs more than a failed one — a failure is a bad day, a dispute is a
+disagreement about whether the work happened at all.
+
+**Quote accuracy is hard to fake.** The quoted duration was signed before
+the work and the actual duration after it, and the receipt cites the offer
+by hash. A provider that systematically under-quotes leaves a signed trail
+of doing so. Crediting accuracy requires holding both the offer and a
+receipt that names it, so a flattering pair cannot be assembled after the
+fact.
+
+## What an intermediary can and cannot do
+
+Every input is verified at the boundary, so an indexer, relay or gateway
+sitting in the path can:
+
+- **delay or withhold** records — you see a smaller market and may get a
+  worse price;
+
+and cannot:
+
+- forge an advert, inflate a provider's capabilities, undercut a quote,
+  re-point an offer at a different job, or manufacture reputation.
+
+Degraded, not corrupted, is the correct failure mode for a
+non-authoritative index — and the reason a buyer who suspects one can go
+to the network directly.
+
+## Reference
+
+`node/crates/c0mpute-market`. The full chain — advert, job, offer,
+selection, receipt, countersignature — runs end to end with no shared
+state between the parties in that crate's `tests/gateway_none.rs`,
+including the hostile-intermediary cases above.

--- a/node/crates/c0mpute-market/Cargo.toml
+++ b/node/crates/c0mpute-market/Cargo.toml
@@ -1,0 +1,16 @@
+[package]
+name = "c0mpute-market"
+version.workspace = true
+edition.workspace = true
+license.workspace = true
+repository.workspace = true
+rust-version.workspace = true
+description = "Provider directory, offer book, receipt-derived reputation, and buyer-side offer selection for the c0mpute network"
+
+[dependencies]
+c0mpute-envelope = { workspace = true }
+serde = { workspace = true }
+thiserror = { workspace = true }
+
+[dev-dependencies]
+serde_json = { workspace = true }

--- a/node/crates/c0mpute-market/src/directory.rs
+++ b/node/crates/c0mpute-market/src/directory.rs
@@ -1,0 +1,337 @@
+//! What this node currently believes about available capacity.
+//!
+//! The directory holds the newest signed advert per provider. It is a
+//! **cache of other people's claims**, never a source of truth, and the
+//! code is written so that stays true:
+//!
+//! - every advert is signature-verified on the way in, so it does not
+//!   matter whether it arrived over gossip, from an indexer, or pasted
+//!   from a file — an indexer that lies produces a rejected insert, not a
+//!   bad match;
+//! - adverts expire, and expiry is checked on read as well as on write,
+//!   so a directory that has not been pruned still cannot hand out stale
+//!   capacity;
+//! - a lower sequence number never replaces a higher one, so replaying an
+//!   old advert cannot roll a provider's claims backwards.
+//!
+//! Nothing here needs a network, a database, or a hosted service.
+
+use std::collections::HashMap;
+
+use c0mpute_envelope::advert::ProviderAdvert;
+use c0mpute_envelope::job::JobManifest;
+use c0mpute_envelope::{Did, Envelope, Timestamp};
+
+use crate::Error;
+use crate::matching::{Mismatch, mismatches};
+
+/// One provider's current claim.
+#[derive(Clone, Debug)]
+pub struct ProviderRecord {
+    pub provider: Did,
+    pub advert: ProviderAdvert,
+    /// Content hash of the sealed advert, so an offer can cite the exact
+    /// claim it was made against.
+    pub advert_hash: c0mpute_envelope::ContentHash,
+}
+
+/// What happened to an advert on the way in.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum Accepted {
+    /// First advert seen from this provider.
+    New,
+    /// Replaced an older advert from the same provider.
+    Superseded,
+    /// Ignored: we already hold this sequence or a newer one.
+    Stale,
+}
+
+/// The newest signed advert per provider.
+#[derive(Debug, Default)]
+pub struct ProviderDirectory {
+    by_provider: HashMap<String, ProviderRecord>,
+}
+
+impl ProviderDirectory {
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Verify and record an advert.
+    ///
+    /// Errors if the envelope does not verify or the advert has expired.
+    /// A stale-but-valid advert is not an error — it is the ordinary
+    /// result of hearing the same provider twice.
+    pub fn insert(
+        &mut self,
+        envelope: &Envelope<ProviderAdvert>,
+        now: &Timestamp,
+    ) -> Result<Accepted, Error> {
+        // Verification happens here, once, at the boundary. Everything
+        // downstream can then treat a ProviderRecord as something the
+        // named provider actually signed.
+        let advert = envelope.open_fresh(now).map_err(Error::Envelope)?;
+        let provider = envelope.signer.clone();
+        let key = provider.as_str().to_string();
+
+        if let Some(existing) = self.by_provider.get(&key) {
+            if !advert.supersedes(&existing.advert) {
+                return Ok(Accepted::Stale);
+            }
+        }
+
+        let outcome = if self.by_provider.contains_key(&key) {
+            Accepted::Superseded
+        } else {
+            Accepted::New
+        };
+
+        self.by_provider.insert(
+            key,
+            ProviderRecord {
+                provider,
+                advert: advert.clone(),
+                advert_hash: envelope.content_hash().map_err(Error::Envelope)?,
+            },
+        );
+        Ok(outcome)
+    }
+
+    /// Providers whose advert is still valid at `now`.
+    pub fn live(&self, now: &Timestamp) -> impl Iterator<Item = &ProviderRecord> {
+        self.by_provider
+            .values()
+            .filter(move |r| !r.advert.expires_at.is_expired_at(now))
+    }
+
+    /// Providers eligible for `job`, in deterministic DID order.
+    ///
+    /// Ordering matters: two nodes running the same policy over the same
+    /// adverts should reach the same answer, and a HashMap's iteration
+    /// order would make that untrue in a way that only shows up
+    /// occasionally.
+    pub fn eligible(&self, job: &JobManifest, now: &Timestamp) -> Vec<ProviderRecord> {
+        let mut out: Vec<ProviderRecord> = self
+            .live(now)
+            .filter(|r| mismatches(&r.advert, &r.provider, job).is_empty())
+            .cloned()
+            .collect();
+        out.sort_by(|a, b| a.provider.as_str().cmp(b.provider.as_str()));
+        out
+    }
+
+    /// [`ProviderDirectory::eligible`], plus why everyone else missed out.
+    ///
+    /// This is what turns "no providers found" from a dead end into a
+    /// diagnosis.
+    pub fn explain(
+        &self,
+        job: &JobManifest,
+        now: &Timestamp,
+    ) -> (Vec<ProviderRecord>, Vec<(Did, Vec<Mismatch>)>) {
+        let mut eligible = Vec::new();
+        let mut rejected = Vec::new();
+        for r in self.live(now) {
+            let ms = mismatches(&r.advert, &r.provider, job);
+            if ms.is_empty() {
+                eligible.push(r.clone());
+            } else {
+                rejected.push((r.provider.clone(), ms));
+            }
+        }
+        eligible.sort_by(|a, b| a.provider.as_str().cmp(b.provider.as_str()));
+        rejected.sort_by(|a, b| a.0.as_str().cmp(b.0.as_str()));
+        (eligible, rejected)
+    }
+
+    /// Look up one provider's current advert.
+    pub fn get(&self, provider: &Did) -> Option<&ProviderRecord> {
+        self.by_provider.get(provider.as_str())
+    }
+
+    /// Drop expired adverts. Optional — reads already ignore them — but
+    /// worth running periodically so a long-lived process does not grow
+    /// without bound on a churning network.
+    pub fn prune(&mut self, now: &Timestamp) -> usize {
+        let before = self.by_provider.len();
+        self.by_provider
+            .retain(|_, r| !r.advert.expires_at.is_expired_at(now));
+        before - self.by_provider.len()
+    }
+
+    /// Total adverts held, including expired ones not yet pruned.
+    pub fn len(&self) -> usize {
+        self.by_provider.len()
+    }
+
+    pub fn is_empty(&self) -> bool {
+        self.by_provider.is_empty()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::test_support::*;
+    use c0mpute_envelope::Money;
+
+    #[test]
+    fn a_verified_advert_is_accepted_and_found() {
+        let mut dir = ProviderDirectory::new();
+        let (did, env) = sealed_advert(7);
+        assert_eq!(dir.insert(&env, &now()).unwrap(), Accepted::New);
+        assert_eq!(dir.len(), 1);
+        assert_eq!(dir.get(&did).unwrap().provider, did);
+        assert_eq!(dir.eligible(&gpu_job(), &now()).len(), 1);
+    }
+
+    #[test]
+    fn a_forged_advert_is_rejected() {
+        // Exactly the attack an untrusted indexer would attempt: hand us a
+        // real provider's identity with claims it never made.
+        let mut dir = ProviderDirectory::new();
+        let (_, mut env) = sealed_advert(7);
+        env.payload.capabilities.gpus = vec![gpu(80, 8, &["cuda"])];
+
+        assert!(dir.insert(&env, &now()).is_err());
+        assert!(dir.is_empty(), "a forgery must not reach the directory");
+    }
+
+    #[test]
+    fn an_expired_advert_is_rejected_on_insert() {
+        let mut dir = ProviderDirectory::new();
+        let (_, env) = sealed_advert(7);
+        let late = ts("2026-09-06T16:20:00.000Z");
+        assert!(dir.insert(&env, &late).is_err());
+        assert!(dir.is_empty());
+    }
+
+    #[test]
+    fn an_advert_that_expires_while_held_stops_being_offered() {
+        // The realistic failure: a provider goes offline and its last
+        // advert sits in our cache. Reads must not surface it as capacity
+        // even if nothing has pruned yet.
+        let mut dir = ProviderDirectory::new();
+        let (_, env) = sealed_advert(7);
+        dir.insert(&env, &now()).unwrap();
+
+        let later = ts("2026-09-06T16:11:00.000Z");
+        assert_eq!(dir.len(), 1, "still held");
+        assert_eq!(dir.live(&later).count(), 0, "but not live");
+        assert!(dir.eligible(&gpu_job(), &later).is_empty());
+
+        assert_eq!(dir.prune(&later), 1);
+        assert!(dir.is_empty());
+    }
+
+    #[test]
+    fn a_higher_sequence_supersedes() {
+        let mut dir = ProviderDirectory::new();
+        let (did, env) = sealed_advert(7);
+        dir.insert(&env, &now()).unwrap();
+
+        let id = identity(7);
+        let (_, mut newer) = provider_seeded(7);
+        newer.sequence = 2;
+        newer.pricing[0].price = Money::new("0.20", "USD");
+        let newer_env = Envelope::seal(&id, newer).unwrap();
+
+        assert_eq!(
+            dir.insert(&newer_env, &now()).unwrap(),
+            Accepted::Superseded
+        );
+        assert_eq!(dir.len(), 1, "one record per provider");
+        assert_eq!(
+            dir.get(&did).unwrap().advert.pricing[0].price.amount,
+            "0.20"
+        );
+    }
+
+    #[test]
+    fn replaying_an_older_advert_cannot_roll_a_provider_back() {
+        let mut dir = ProviderDirectory::new();
+        let id = identity(7);
+
+        let (did, mut v2) = provider_seeded(7);
+        v2.sequence = 2;
+        v2.capabilities.workloads = vec![WORKLOAD.into()];
+        dir.insert(&Envelope::seal(&id, v2).unwrap(), &now())
+            .unwrap();
+
+        // A perfectly valid, correctly signed, older advert.
+        let (_, v1) = provider_seeded(7);
+        let replayed = Envelope::seal(&id, v1).unwrap();
+        assert_eq!(dir.insert(&replayed, &now()).unwrap(), Accepted::Stale);
+        assert_eq!(dir.get(&did).unwrap().advert.sequence, 2);
+    }
+
+    #[test]
+    fn re_inserting_the_same_sequence_is_stale_not_an_error() {
+        let mut dir = ProviderDirectory::new();
+        let (_, env) = sealed_advert(7);
+        dir.insert(&env, &now()).unwrap();
+        assert_eq!(dir.insert(&env, &now()).unwrap(), Accepted::Stale);
+        assert_eq!(dir.len(), 1);
+    }
+
+    #[test]
+    fn providers_are_tracked_independently() {
+        let mut dir = ProviderDirectory::new();
+        for seed in [7u8, 8, 9] {
+            let (_, env) = sealed_advert(seed);
+            dir.insert(&env, &now()).unwrap();
+        }
+        assert_eq!(dir.len(), 3);
+        assert_eq!(dir.eligible(&gpu_job(), &now()).len(), 3);
+    }
+
+    #[test]
+    fn eligible_order_is_deterministic() {
+        let mut a = ProviderDirectory::new();
+        let mut b = ProviderDirectory::new();
+        for seed in [7u8, 8, 9, 10, 11] {
+            let (_, env) = sealed_advert(seed);
+            a.insert(&env, &now()).unwrap();
+        }
+        // Same adverts, opposite insertion order.
+        for seed in [11u8, 10, 9, 8, 7] {
+            let (_, env) = sealed_advert(seed);
+            b.insert(&env, &now()).unwrap();
+        }
+        let ids = |d: &ProviderDirectory| -> Vec<String> {
+            d.eligible(&gpu_job(), &now())
+                .iter()
+                .map(|r| r.provider.as_str().to_string())
+                .collect()
+        };
+        assert_eq!(ids(&a), ids(&b));
+    }
+
+    #[test]
+    fn explain_separates_the_eligible_from_the_rest() {
+        let mut dir = ProviderDirectory::new();
+        let (_, ok) = sealed_advert(7);
+        dir.insert(&ok, &now()).unwrap();
+
+        let (_, mut weak) = provider_seeded(8);
+        weak.capabilities.gpus = vec![];
+        dir.insert(&Envelope::seal(&identity(8), weak).unwrap(), &now())
+            .unwrap();
+
+        let (eligible, rejected) = dir.explain(&gpu_job(), &now());
+        assert_eq!(eligible.len(), 1);
+        assert_eq!(rejected.len(), 1);
+        assert!(matches!(rejected[0].1[0], Mismatch::Gpu(_)));
+    }
+
+    #[test]
+    fn the_advert_hash_is_recorded_so_an_offer_can_cite_it() {
+        let mut dir = ProviderDirectory::new();
+        let (did, env) = sealed_advert(7);
+        dir.insert(&env, &now()).unwrap();
+        assert_eq!(
+            dir.get(&did).unwrap().advert_hash,
+            env.content_hash().unwrap()
+        );
+    }
+}

--- a/node/crates/c0mpute-market/src/lib.rs
+++ b/node/crates/c0mpute-market/src/lib.rs
@@ -1,0 +1,75 @@
+//! The buyer-side market: who can do this job, what did they quote, and
+//! which quote wins.
+//!
+//! This crate is the answer to "if nobody is in the middle, who decides?"
+//! The answer is: whoever is running this code. A buyer's CLI, a gateway
+//! the buyer explicitly delegated to, or an organization's private
+//! scheduler all link the same logic and reach the same kind of decision
+//! — and none of them is privileged over the others, because there is no
+//! network-wide matcher for them to be privileged *by*.
+//!
+//! ```text
+//! adverts ──> ProviderDirectory ──┐
+//!                                 ├──> select(policy) ──> winning offer
+//! offers  ──> OfferBook ──────────┤
+//! receipts ─> ReputationLedger ───┘
+//! ```
+//!
+//! Four pieces:
+//!
+//! - [`directory::ProviderDirectory`] — the newest signed advert per
+//!   provider, expiry and supersession enforced.
+//! - [`offers::OfferBook`] — verified offers for one job, one slot per
+//!   provider, order-independent.
+//! - [`reputation::ReputationLedger`] — provider statistics derived from
+//!   signed receipts, rebuildable from a receipt log.
+//! - [`policy::select`] — ranks eligible offers under a named policy.
+//!
+//! ## What makes this trustworthy without a trusted party
+//!
+//! Every input is a signed envelope, verified at the boundary as it
+//! enters. Nothing downstream has to ask where a record came from: a
+//! forged advert fails on insert, a receipt about someone else's work is
+//! refused, and an offer that was edited in flight never reaches scoring.
+//! An indexer that feeds this crate can be stale, partial or hostile and
+//! the worst it achieves is showing you fewer providers than exist.
+//!
+//! ## Deliberate non-dependencies
+//!
+//! No transport, no HTTP, no settlement product — same rule as
+//! `c0mpute-envelope` (DIP-0024). Time enters as a `Timestamp` parameter
+//! rather than being read from the clock, which is what makes every
+//! expiry and freshness path testable rather than a matter of waiting.
+
+pub mod directory;
+pub mod matching;
+pub mod offers;
+pub mod policy;
+pub mod reputation;
+
+#[cfg(test)]
+mod test_support;
+
+pub use directory::{Accepted as AdvertAccepted, ProviderDirectory, ProviderRecord};
+pub use matching::{Mismatch, is_eligible, mismatches, summarize};
+pub use offers::{Accepted as OfferAccepted, OfferBook, OfferRecord};
+pub use policy::{ScoredOffer, Selection, SelectionPolicy, select};
+pub use reputation::{ProviderStats, ReputationLedger};
+
+/// Everything that can go wrong running a market.
+#[derive(Debug, thiserror::Error)]
+pub enum Error {
+    /// A record failed verification, expiry, or its own validity rules.
+    #[error(transparent)]
+    Envelope(c0mpute_envelope::Error),
+
+    /// A record verified, but does not say what the caller was told it
+    /// said — a receipt signed by the wrong identity, an offer for another
+    /// job, a quote paired with an unrelated receipt.
+    #[error("untrusted input: {0}")]
+    Untrusted(String),
+
+    /// Selection was asked to choose from nothing.
+    #[error("no eligible offers to choose from")]
+    NoOffers,
+}

--- a/node/crates/c0mpute-market/src/matching.rs
+++ b/node/crates/c0mpute-market/src/matching.rs
@@ -1,0 +1,351 @@
+//! Does this provider satisfy this job's requirements?
+//!
+//! Eligibility is a hard filter, evaluated before price ever comes into
+//! it. A provider that fails here is not a worse choice — it is not a
+//! choice.
+//!
+//! Every rejection carries a [`Mismatch`] saying which requirement failed
+//! and why. That is not decoration: "no providers found" is the single
+//! most common thing a buyer will see on a young network, and being able
+//! to answer *why* — nobody has 24 GiB of VRAM, or six providers do but
+//! none disclosed a region — is the difference between a usable market
+//! and a black box.
+
+use c0mpute_envelope::advert::ProviderAdvert;
+use c0mpute_envelope::job::JobManifest;
+use c0mpute_envelope::{Did, TrustTier};
+
+/// Why a provider is not eligible for a job.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub enum Mismatch {
+    /// The provider does not advertise this workload at all.
+    WorkloadNotOffered { wanted: String },
+    /// Not on the buyer's allowlist (the `private` trust tier).
+    NotAllowlisted,
+    /// The provider's claimed tier does not satisfy the job's.
+    TrustTier { wanted: TrustTier, has: TrustTier },
+    /// No disclosed region, or a region the buyer did not ask for.
+    Region {
+        wanted: Vec<String>,
+        has: Option<String>,
+    },
+    /// Not enough GPUs, VRAM, or a missing GPU feature.
+    Gpu(String),
+    /// Not enough CPU cores.
+    CpuCores { wanted: u32, has: u32 },
+    /// Not enough memory.
+    Memory { wanted: String, has: u32 },
+}
+
+impl std::fmt::Display for Mismatch {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Mismatch::WorkloadNotOffered { wanted } => {
+                write!(f, "does not offer workload {wanted}")
+            }
+            Mismatch::NotAllowlisted => {
+                write!(f, "not on the job's provider allowlist")
+            }
+            Mismatch::TrustTier { wanted, has } => {
+                write!(f, "claims trust tier {has:?}, job requires {wanted:?}")
+            }
+            Mismatch::Region { wanted, has } => match has {
+                Some(r) => write!(f, "is in region {r}, job wants one of {wanted:?}"),
+                None => write!(
+                    f,
+                    "discloses no region, and the job restricts to {wanted:?}"
+                ),
+            },
+            Mismatch::Gpu(why) => write!(f, "GPU requirement unmet: {why}"),
+            Mismatch::CpuCores { wanted, has } => {
+                write!(f, "has {has} CPU cores, job needs {wanted}")
+            }
+            Mismatch::Memory { wanted, has } => {
+                write!(f, "has {has} GiB of memory, job needs {wanted}")
+            }
+        }
+    }
+}
+
+/// Check `advert` against `job`, returning every requirement it fails.
+///
+/// Returns all mismatches rather than the first, so a buyer looking at an
+/// empty market can see the whole shape of the problem in one pass instead
+/// of fixing one constraint at a time.
+pub fn mismatches(advert: &ProviderAdvert, provider: &Did, job: &JobManifest) -> Vec<Mismatch> {
+    let req = &job.requirements;
+    let caps = &advert.capabilities;
+    let mut out = Vec::new();
+
+    if !advert.runs(&job.workload.type_id) {
+        out.push(Mismatch::WorkloadNotOffered {
+            wanted: job.workload.type_id.clone(),
+        });
+    }
+
+    // An allowlist, when present, is absolute — it is checked before the
+    // tier, because "one of these identities" is a stronger statement than
+    // any tier claim and a provider cannot talk its way onto the list.
+    if !req.providers.is_empty() && !req.providers.contains(provider) {
+        out.push(Mismatch::NotAllowlisted);
+    } else if !advert.trust.tier.satisfies(req.trust_tier) {
+        out.push(Mismatch::TrustTier {
+            wanted: req.trust_tier,
+            has: advert.trust.tier,
+        });
+    }
+
+    if !req.region.is_empty() {
+        let has = advert.disclosure.as_ref().and_then(|d| d.region.as_deref());
+        // Undisclosed is not a match. A provider that withheld its region
+        // is not excluded from the network, only from jobs that constrain
+        // on one — which is exactly the trade the disclosure opt-in makes.
+        if !has.is_some_and(|r| req.region.iter().any(|w| w == r)) {
+            out.push(Mismatch::Region {
+                wanted: req.region.clone(),
+                has: has.map(str::to_string),
+            });
+        }
+    }
+
+    if let Some(want) = &req.gpu {
+        // Count GPUs that individually satisfy the VRAM and feature
+        // requirements. Summing VRAM across cards would be wrong: a job
+        // needing 24 GiB cannot run on two 12 GiB cards.
+        let usable: u32 = caps
+            .gpus
+            .iter()
+            .filter(|g| {
+                want.vram_gib.is_none_or(|b| b.contains(g.vram_gib))
+                    && want
+                        .features
+                        .iter()
+                        .all(|f| g.features.iter().any(|has| has == f))
+            })
+            .map(|g| g.count)
+            .sum();
+
+        if usable < want.count {
+            out.push(Mismatch::Gpu(if caps.gpus.is_empty() {
+                "provider advertises no GPU".to_string()
+            } else {
+                format!(
+                    "needs {} GPU(s) meeting the spec, provider has {usable}",
+                    want.count
+                )
+            }));
+        }
+    }
+
+    if let Some(cores) = req.cpu_cores {
+        if caps.cpu.cores < cores {
+            out.push(Mismatch::CpuCores {
+                wanted: cores,
+                has: caps.cpu.cores,
+            });
+        }
+    }
+
+    if let Some(mem) = &req.memory_gib {
+        if !mem.contains(caps.memory_gib) {
+            out.push(Mismatch::Memory {
+                wanted: describe_bound(mem),
+                has: caps.memory_gib,
+            });
+        }
+    }
+
+    out
+}
+
+/// Whether `advert` satisfies every requirement in `job`.
+pub fn is_eligible(advert: &ProviderAdvert, provider: &Did, job: &JobManifest) -> bool {
+    mismatches(advert, provider, job).is_empty()
+}
+
+fn describe_bound(b: &c0mpute_envelope::job::Bound) -> String {
+    match (b.min, b.max) {
+        (Some(lo), Some(hi)) => format!("{lo}-{hi}"),
+        (Some(lo), None) => format!("at least {lo}"),
+        (None, Some(hi)) => format!("at most {hi}"),
+        (None, None) => "any".into(),
+    }
+}
+
+/// A short human summary of why a set of providers was rejected, for the
+/// "no eligible providers" case.
+pub fn summarize(rejections: &[(Did, Vec<Mismatch>)]) -> String {
+    if rejections.is_empty() {
+        return "no providers known".into();
+    }
+    let mut counts: Vec<(String, usize)> = Vec::new();
+    for (_, ms) in rejections {
+        for m in ms {
+            let key = match m {
+                Mismatch::WorkloadNotOffered { .. } => "workload not offered",
+                Mismatch::NotAllowlisted => "not allowlisted",
+                Mismatch::TrustTier { .. } => "trust tier too low",
+                Mismatch::Region { .. } => "region",
+                Mismatch::Gpu(_) => "GPU",
+                Mismatch::CpuCores { .. } => "CPU cores",
+                Mismatch::Memory { .. } => "memory",
+            };
+            match counts.iter_mut().find(|(k, _)| k == key) {
+                Some((_, n)) => *n += 1,
+                None => counts.push((key.to_string(), 1)),
+            }
+        }
+    }
+    counts.sort_by(|a, b| b.1.cmp(&a.1).then_with(|| a.0.cmp(&b.0)));
+    let parts: Vec<String> = counts.iter().map(|(k, n)| format!("{k}: {n}")).collect();
+    format!(
+        "{} provider(s) rejected — {}",
+        rejections.len(),
+        parts.join(", ")
+    )
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::test_support::*;
+
+    #[test]
+    fn a_matching_provider_is_eligible() {
+        let (did, advert) = gpu_provider();
+        assert!(is_eligible(&advert, &did, &gpu_job()));
+        assert_eq!(mismatches(&advert, &did, &gpu_job()), vec![]);
+    }
+
+    #[test]
+    fn a_provider_that_does_not_offer_the_workload_is_rejected() {
+        let (did, mut advert) = gpu_provider();
+        advert.capabilities.workloads = vec!["whisper.transcribe".into()];
+        let ms = mismatches(&advert, &did, &gpu_job());
+        assert!(matches!(ms[0], Mismatch::WorkloadNotOffered { .. }));
+    }
+
+    #[test]
+    fn vram_is_not_summed_across_cards() {
+        // Two 12 GiB cards do not satisfy a 24 GiB requirement: a model
+        // that does not fit on one card does not fit on two by addition.
+        let (did, mut advert) = gpu_provider();
+        advert.capabilities.gpus = vec![gpu(12, 2, &["cuda"])];
+        let ms = mismatches(&advert, &did, &gpu_job());
+        assert!(matches!(ms[0], Mismatch::Gpu(_)), "got {ms:?}");
+    }
+
+    #[test]
+    fn multiple_qualifying_cards_do_count_toward_the_requested_count() {
+        let (did, mut advert) = gpu_provider();
+        advert.capabilities.gpus = vec![gpu(24, 4, &["cuda"])];
+        let mut job = gpu_job();
+        job.requirements.gpu.as_mut().unwrap().count = 3;
+        assert!(is_eligible(&advert, &did, &job));
+
+        job.requirements.gpu.as_mut().unwrap().count = 5;
+        assert!(!is_eligible(&advert, &did, &job));
+    }
+
+    #[test]
+    fn a_missing_gpu_feature_disqualifies_the_card() {
+        let (did, mut advert) = gpu_provider();
+        advert.capabilities.gpus = vec![gpu(24, 1, &["rocm"])];
+        assert!(!is_eligible(&advert, &did, &gpu_job()));
+    }
+
+    #[test]
+    fn no_gpu_at_all_reports_that_specifically() {
+        let (did, mut advert) = gpu_provider();
+        advert.capabilities.gpus = vec![];
+        let ms = mismatches(&advert, &did, &gpu_job());
+        assert_eq!(ms, vec![Mismatch::Gpu("provider advertises no GPU".into())]);
+    }
+
+    #[test]
+    fn an_undisclosed_region_cannot_match_a_region_constraint() {
+        let (did, mut advert) = gpu_provider();
+        advert.disclosure = None;
+        let mut job = gpu_job();
+        job.requirements.region = vec!["us-west".into()];
+        let ms = mismatches(&advert, &did, &job);
+        assert!(matches!(ms[0], Mismatch::Region { has: None, .. }));
+    }
+
+    #[test]
+    fn no_region_constraint_accepts_an_undisclosed_provider() {
+        let (did, mut advert) = gpu_provider();
+        advert.disclosure = None;
+        let mut job = gpu_job();
+        job.requirements.region = vec![];
+        assert!(is_eligible(&advert, &did, &job));
+    }
+
+    #[test]
+    fn a_weaker_trust_tier_is_rejected() {
+        let (did, mut advert) = gpu_provider();
+        advert.trust.tier = TrustTier::Community;
+        let mut job = gpu_job();
+        job.requirements.trust_tier = TrustTier::Verified;
+        let ms = mismatches(&advert, &did, &job);
+        assert!(matches!(ms[0], Mismatch::TrustTier { .. }));
+    }
+
+    #[test]
+    fn the_allowlist_beats_a_tier_claim() {
+        // A provider can claim any tier it likes. It cannot claim its way
+        // onto someone else's allowlist.
+        let (did, mut advert) = gpu_provider();
+        advert.trust.tier = TrustTier::Private;
+        let mut job = gpu_job();
+        job.requirements.trust_tier = TrustTier::Private;
+        job.requirements.providers = vec![identity(99).did().clone()];
+
+        let ms = mismatches(&advert, &did, &job);
+        assert_eq!(ms, vec![Mismatch::NotAllowlisted]);
+
+        job.requirements.providers = vec![did.clone()];
+        assert!(is_eligible(&advert, &did, &job));
+    }
+
+    #[test]
+    fn insufficient_cpu_or_memory_is_rejected() {
+        let (did, mut advert) = gpu_provider();
+        advert.capabilities.cpu.cores = 2;
+        advert.capabilities.memory_gib = 8;
+        let mut job = gpu_job();
+        job.requirements.cpu_cores = Some(16);
+
+        let ms = mismatches(&advert, &did, &job);
+        assert!(ms.contains(&Mismatch::CpuCores { wanted: 16, has: 2 }));
+        assert!(ms.iter().any(|m| matches!(m, Mismatch::Memory { .. })));
+    }
+
+    #[test]
+    fn every_failing_requirement_is_reported_not_just_the_first() {
+        let (did, mut advert) = gpu_provider();
+        advert.capabilities.workloads = vec!["other.thing".into()];
+        advert.capabilities.gpus = vec![];
+        advert.capabilities.cpu.cores = 1;
+        let mut job = gpu_job();
+        job.requirements.cpu_cores = Some(8);
+
+        let ms = mismatches(&advert, &did, &job);
+        assert!(ms.len() >= 3, "expected several mismatches, got {ms:?}");
+    }
+
+    #[test]
+    fn summarize_counts_the_common_reasons() {
+        let (did, mut advert) = gpu_provider();
+        advert.capabilities.gpus = vec![];
+        let ms = mismatches(&advert, &did, &gpu_job());
+        let s = summarize(&[(did.clone(), ms.clone()), (did, ms)]);
+        assert!(s.contains("2 provider(s) rejected"), "{s}");
+        assert!(s.contains("GPU"), "{s}");
+    }
+
+    #[test]
+    fn summarize_handles_an_empty_network() {
+        assert_eq!(summarize(&[]), "no providers known");
+    }
+}

--- a/node/crates/c0mpute-market/src/offers.rs
+++ b/node/crates/c0mpute-market/src/offers.rs
@@ -1,0 +1,328 @@
+//! Offers collected for one job.
+//!
+//! The book holds at most one live offer per provider and verifies every
+//! one on the way in. Three checks are hard gates rather than preferences,
+//! because accepting an offer that fails any of them is a bug, not a bad
+//! trade:
+//!
+//!   1. it is signed, and by the provider it claims to be from;
+//!   2. it is for *this* job, within the price cap, and can finish before
+//!      the deadline (`Offer::check_against`);
+//!   3. it has not expired.
+//!
+//! Price is compared exactly, through decimal-string arithmetic, never as
+//! a float. Scoring later uses floats — a ranking heuristic can afford
+//! rounding — but the question "is this within my cap" cannot.
+
+use std::collections::HashMap;
+
+use c0mpute_envelope::job::JobManifest;
+use c0mpute_envelope::{Did, Envelope, Offer, Timestamp};
+
+use crate::Error;
+
+/// A verified offer, with the identity that signed it.
+#[derive(Clone, Debug)]
+pub struct OfferRecord {
+    pub provider: Did,
+    pub offer: Offer,
+    /// Content hash of the sealed offer — what a receipt cites to prove
+    /// the price charged is the price quoted.
+    pub offer_hash: c0mpute_envelope::ContentHash,
+}
+
+/// Live offers for one job, one per provider.
+#[derive(Debug)]
+pub struct OfferBook {
+    job_id: c0mpute_envelope::ContentHash,
+    by_provider: HashMap<String, OfferRecord>,
+}
+
+impl OfferBook {
+    /// Open a book for `job`.
+    pub fn for_job(job: &JobManifest) -> Result<Self, Error> {
+        Ok(Self {
+            job_id: job.id().map_err(Error::Envelope)?,
+            by_provider: HashMap::new(),
+        })
+    }
+
+    /// Verify an offer and record it if it beats what that provider has
+    /// already quoted.
+    ///
+    /// Keeping the provider's **best** offer rather than its most recent
+    /// makes the book independent of arrival order, so two buyers who
+    /// heard the same offers in different sequences select the same
+    /// winner. A provider improving its quote is legitimate; a provider
+    /// worsening it after the fact should not un-quote the better price.
+    pub fn submit(
+        &mut self,
+        envelope: &Envelope<Offer>,
+        job: &JobManifest,
+        now: &Timestamp,
+    ) -> Result<Accepted, Error> {
+        let offer = envelope.open_fresh(now).map_err(Error::Envelope)?;
+        offer.check_against(job).map_err(Error::Envelope)?;
+
+        // check_against already compares the job id, but only against the
+        // manifest handed in. Comparing to the book's own id stops a
+        // caller from mixing books and jobs.
+        if offer.job != self.job_id {
+            return Err(Error::Untrusted(format!(
+                "offer is for job {} but this book is for {}",
+                offer.job, self.job_id
+            )));
+        }
+
+        let provider = envelope.signer.clone();
+        let key = provider.as_str().to_string();
+        let record = OfferRecord {
+            provider,
+            offer: offer.clone(),
+            offer_hash: envelope.content_hash().map_err(Error::Envelope)?,
+        };
+
+        match self.by_provider.get(&key) {
+            Some(existing) if !improves_on(&record, existing)? => Ok(Accepted::NotBetter),
+            Some(_) => {
+                self.by_provider.insert(key, record);
+                Ok(Accepted::Improved)
+            }
+            None => {
+                self.by_provider.insert(key, record);
+                Ok(Accepted::New)
+            }
+        }
+    }
+
+    /// Offers still live at `now`, in deterministic provider order.
+    pub fn live(&self, now: &Timestamp) -> Vec<OfferRecord> {
+        let mut out: Vec<OfferRecord> = self
+            .by_provider
+            .values()
+            .filter(|r| r.offer.is_live_at(now))
+            .cloned()
+            .collect();
+        out.sort_by(|a, b| a.provider.as_str().cmp(b.provider.as_str()));
+        out
+    }
+
+    /// Restrict to providers that are also eligible per the directory.
+    ///
+    /// An offer from an ineligible provider is not an attack — a provider
+    /// may bid on work it cannot do, or its advert may have lapsed between
+    /// quoting and now — but it must not win.
+    pub fn live_from(&self, eligible: &[Did], now: &Timestamp) -> Vec<OfferRecord> {
+        self.live(now)
+            .into_iter()
+            .filter(|r| eligible.contains(&r.provider))
+            .collect()
+    }
+
+    pub fn len(&self) -> usize {
+        self.by_provider.len()
+    }
+
+    pub fn is_empty(&self) -> bool {
+        self.by_provider.is_empty()
+    }
+}
+
+/// What happened to a submitted offer.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum Accepted {
+    /// First offer from this provider.
+    New,
+    /// Replaced this provider's previous, worse offer.
+    Improved,
+    /// Kept the provider's existing offer instead.
+    NotBetter,
+}
+
+/// Cheaper wins; equal price, faster wins; still equal, the lower offer
+/// hash wins so the answer never depends on which arrived first.
+fn improves_on(new: &OfferRecord, existing: &OfferRecord) -> Result<bool, Error> {
+    use std::cmp::Ordering;
+    let by_price = new
+        .offer
+        .price
+        .cmp_amount(&existing.offer.price)
+        .map_err(Error::Envelope)?;
+    Ok(match by_price {
+        Ordering::Less => true,
+        Ordering::Greater => false,
+        Ordering::Equal => match new
+            .offer
+            .expected_duration_ms
+            .cmp(&existing.offer.expected_duration_ms)
+        {
+            Ordering::Less => true,
+            Ordering::Greater => false,
+            Ordering::Equal => new.offer_hash.to_wire() < existing.offer_hash.to_wire(),
+        },
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::test_support::*;
+    use c0mpute_envelope::Money;
+
+    #[test]
+    fn a_valid_offer_is_accepted() {
+        let job = gpu_job();
+        let mut book = OfferBook::for_job(&job).unwrap();
+        let env = offer_from(7, &job, "0.05", 12_000);
+        assert_eq!(book.submit(&env, &job, &now()).unwrap(), Accepted::New);
+        assert_eq!(book.live(&now()).len(), 1);
+    }
+
+    #[test]
+    fn a_tampered_offer_is_rejected() {
+        let job = gpu_job();
+        let mut book = OfferBook::for_job(&job).unwrap();
+        let mut env = offer_from(7, &job, "0.05", 12_000);
+        env.payload.price = Money::new("0.01", "USD");
+        assert!(book.submit(&env, &job, &now()).is_err());
+        assert!(book.is_empty());
+    }
+
+    #[test]
+    fn an_over_cap_offer_is_rejected() {
+        // The cap is "0.10". "0.9" is over it numerically, and *under* it
+        // lexically — the case a string comparison gets wrong.
+        let job = gpu_job();
+        let mut book = OfferBook::for_job(&job).unwrap();
+        let env = offer_from(7, &job, "0.9", 12_000);
+        assert!(book.submit(&env, &job, &now()).is_err());
+
+        let ok = offer_from(7, &job, "0.09", 12_000);
+        book.submit(&ok, &job, &now()).unwrap();
+    }
+
+    #[test]
+    fn an_offer_that_cannot_meet_the_deadline_is_rejected() {
+        let job = gpu_job();
+        let mut book = OfferBook::for_job(&job).unwrap();
+        // Starts by 16:01, runs 10 minutes, deadline is 16:10.
+        let env = offer_from(7, &job, "0.05", 10 * 60 * 1000);
+        assert!(book.submit(&env, &job, &now()).is_err());
+    }
+
+    #[test]
+    fn an_expired_offer_is_rejected() {
+        let job = gpu_job();
+        let mut book = OfferBook::for_job(&job).unwrap();
+        let env = offer_from(7, &job, "0.05", 12_000);
+        let late = ts("2026-09-06T16:05:00.000Z");
+        assert!(book.submit(&env, &job, &late).is_err());
+    }
+
+    #[test]
+    fn an_offer_for_another_job_is_rejected() {
+        let job = gpu_job();
+        let mut other = gpu_job();
+        other.economics.max_price = Money::new("5.00", "USD");
+
+        let mut book = OfferBook::for_job(&job).unwrap();
+        let env = offer_from(7, &other, "0.05", 12_000);
+        assert!(book.submit(&env, &job, &now()).is_err());
+    }
+
+    #[test]
+    fn a_provider_holds_one_slot_and_may_improve_it() {
+        let job = gpu_job();
+        let mut book = OfferBook::for_job(&job).unwrap();
+        book.submit(&offer_from(7, &job, "0.08", 12_000), &job, &now())
+            .unwrap();
+        assert_eq!(
+            book.submit(&offer_from(7, &job, "0.05", 12_000), &job, &now())
+                .unwrap(),
+            Accepted::Improved
+        );
+        assert_eq!(book.len(), 1, "still one slot");
+        assert_eq!(book.live(&now())[0].offer.price.amount, "0.05");
+    }
+
+    #[test]
+    fn a_provider_cannot_walk_back_a_better_quote() {
+        let job = gpu_job();
+        let mut book = OfferBook::for_job(&job).unwrap();
+        book.submit(&offer_from(7, &job, "0.05", 12_000), &job, &now())
+            .unwrap();
+        assert_eq!(
+            book.submit(&offer_from(7, &job, "0.09", 12_000), &job, &now())
+                .unwrap(),
+            Accepted::NotBetter
+        );
+        assert_eq!(book.live(&now())[0].offer.price.amount, "0.05");
+    }
+
+    #[test]
+    fn the_book_is_independent_of_arrival_order() {
+        let job = gpu_job();
+        let prices = ["0.08", "0.05", "0.09"];
+
+        let mut forward = OfferBook::for_job(&job).unwrap();
+        for p in prices {
+            let _ = forward.submit(&offer_from(7, &job, p, 12_000), &job, &now());
+        }
+        let mut reverse = OfferBook::for_job(&job).unwrap();
+        for p in prices.iter().rev() {
+            let _ = reverse.submit(&offer_from(7, &job, p, 12_000), &job, &now());
+        }
+
+        assert_eq!(
+            forward.live(&now())[0].offer.price.amount,
+            reverse.live(&now())[0].offer.price.amount
+        );
+        assert_eq!(forward.live(&now())[0].offer.price.amount, "0.05");
+    }
+
+    #[test]
+    fn equal_prices_are_broken_by_speed() {
+        let job = gpu_job();
+        let mut book = OfferBook::for_job(&job).unwrap();
+        book.submit(&offer_from(7, &job, "0.05", 20_000), &job, &now())
+            .unwrap();
+        book.submit(&offer_from(7, &job, "0.05", 9_000), &job, &now())
+            .unwrap();
+        assert_eq!(book.live(&now())[0].offer.expected_duration_ms, 9_000);
+    }
+
+    #[test]
+    fn several_providers_each_get_a_slot() {
+        let job = gpu_job();
+        let mut book = OfferBook::for_job(&job).unwrap();
+        for seed in [7u8, 8, 9] {
+            book.submit(&offer_from(seed, &job, "0.05", 12_000), &job, &now())
+                .unwrap();
+        }
+        assert_eq!(book.len(), 3);
+    }
+
+    #[test]
+    fn live_from_filters_out_ineligible_providers() {
+        let job = gpu_job();
+        let mut book = OfferBook::for_job(&job).unwrap();
+        for seed in [7u8, 8] {
+            book.submit(&offer_from(seed, &job, "0.05", 12_000), &job, &now())
+                .unwrap();
+        }
+        let only_seven = vec![identity(7).did().clone()];
+        assert_eq!(book.live_from(&only_seven, &now()).len(), 1);
+        assert_eq!(book.live_from(&[], &now()).len(), 0);
+    }
+
+    #[test]
+    fn offers_drop_out_when_they_expire() {
+        let job = gpu_job();
+        let mut book = OfferBook::for_job(&job).unwrap();
+        book.submit(&offer_from(7, &job, "0.05", 12_000), &job, &now())
+            .unwrap();
+        // The fixture's offers expire at 16:00:30.
+        assert_eq!(book.live(&ts("2026-09-06T16:00:29.000Z")).len(), 1);
+        assert_eq!(book.live(&ts("2026-09-06T16:00:31.000Z")).len(), 0);
+    }
+}

--- a/node/crates/c0mpute-market/src/policy.rs
+++ b/node/crates/c0mpute-market/src/policy.rs
@@ -1,0 +1,526 @@
+//! Buyer-side offer selection.
+//!
+//! This is where "the buyer decides" stops being a slogan. Nothing on the
+//! network ranks these offers; this function does, on the buyer's machine,
+//! under a policy the buyer named.
+//!
+//! ## Eligibility is not scoring
+//!
+//! By the time an offer reaches here it has already passed the hard gates
+//! in [`crate::offers`] — right job, within cap, meets the deadline,
+//! signed by an eligible provider. Those are correctness. What follows is
+//! *preference*, and reasonable buyers disagree about it. Two nodes running
+//! different policies over identical offers are both right; two nodes
+//! running the *same* policy over identical offers must agree, which is
+//! why every tie here breaks deterministically.
+//!
+//! ## Why not just take the cheapest
+//!
+//! Pure lowest-bid selection is how a market races to the bottom and
+//! becomes unreliable: the cheapest quote often comes from the provider
+//! most likely to disappear mid-job, and the buyer pays for that in
+//! retries. [`SelectionPolicy::Balanced`] is the default for that reason —
+//! it prices reputation alongside money.
+
+use c0mpute_envelope::job::JobManifest;
+use c0mpute_envelope::{Did, Money, TrustTier};
+
+use crate::Error;
+use crate::offers::OfferRecord;
+use crate::reputation::ReputationLedger;
+
+/// How to rank eligible offers.
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
+pub enum SelectionPolicy {
+    /// Lowest price, full stop.
+    Cheapest,
+    /// Shortest quoted duration.
+    Fastest,
+    /// Price, speed and reputation together. The default.
+    #[default]
+    Balanced,
+    /// Reputation and trust tier first, price last.
+    Trusted,
+    /// For allowlisted work: trust and reputation, then price. Requires
+    /// the job to carry a provider allowlist — without one, "private" is
+    /// a preference rather than a guarantee, and the caller almost
+    /// certainly meant something else.
+    Private,
+}
+
+impl SelectionPolicy {
+    /// Weights for (price, speed, reputation, trust). Each is `0.0..=1.0`
+    /// and they need not sum to 1 — scores are compared, not published.
+    fn weights(self) -> Weights {
+        match self {
+            SelectionPolicy::Cheapest => Weights::new(1.0, 0.0, 0.0, 0.0),
+            SelectionPolicy::Fastest => Weights::new(0.0, 1.0, 0.0, 0.0),
+            SelectionPolicy::Balanced => Weights::new(0.4, 0.2, 0.4, 0.0),
+            SelectionPolicy::Trusted => Weights::new(0.2, 0.0, 0.5, 0.3),
+            SelectionPolicy::Private => Weights::new(0.2, 0.0, 0.3, 0.5),
+        }
+    }
+
+    /// Parse a `--policy` value.
+    pub fn parse(s: &str) -> Result<Self, Error> {
+        match s {
+            "cheapest" => Ok(Self::Cheapest),
+            "fastest" => Ok(Self::Fastest),
+            "balanced" => Ok(Self::Balanced),
+            "trusted" => Ok(Self::Trusted),
+            "private" => Ok(Self::Private),
+            other => Err(Error::Untrusted(format!(
+                "unknown policy {other:?}; expected one of \
+                 cheapest, fastest, balanced, trusted, private"
+            ))),
+        }
+    }
+
+    pub fn as_str(self) -> &'static str {
+        match self {
+            Self::Cheapest => "cheapest",
+            Self::Fastest => "fastest",
+            Self::Balanced => "balanced",
+            Self::Trusted => "trusted",
+            Self::Private => "private",
+        }
+    }
+}
+
+#[derive(Clone, Copy, Debug)]
+struct Weights {
+    price: f64,
+    speed: f64,
+    reputation: f64,
+    trust: f64,
+}
+
+impl Weights {
+    fn new(price: f64, speed: f64, reputation: f64, trust: f64) -> Self {
+        Self {
+            price,
+            speed,
+            reputation,
+            trust,
+        }
+    }
+}
+
+/// A scored candidate, kept so a buyer can see *why* it lost.
+#[derive(Clone, Debug)]
+pub struct ScoredOffer {
+    pub record: OfferRecord,
+    pub total: f64,
+    pub price: f64,
+    pub speed: f64,
+    pub reputation: f64,
+    pub trust: f64,
+}
+
+/// The outcome of a selection.
+#[derive(Clone, Debug)]
+pub struct Selection {
+    pub policy: SelectionPolicy,
+    /// Best first.
+    pub ranked: Vec<ScoredOffer>,
+}
+
+impl Selection {
+    pub fn winner(&self) -> &ScoredOffer {
+        &self.ranked[0]
+    }
+
+    pub fn runners_up(&self) -> &[ScoredOffer] {
+        &self.ranked[1..]
+    }
+
+    /// One line explaining the choice, for `--json` output or a log.
+    pub fn explain(&self) -> String {
+        let w = self.winner();
+        format!(
+            "{} won under {} at {} {} ({}ms quoted, reputation {:.2}) — {} other offer(s)",
+            w.record.provider,
+            self.policy.as_str(),
+            w.record.offer.price.amount,
+            w.record.offer.price.currency,
+            w.record.offer.expected_duration_ms,
+            w.reputation,
+            self.runners_up().len()
+        )
+    }
+}
+
+/// Rank `offers` and pick a winner.
+///
+/// `trust_of` supplies each provider's claimed tier from the directory;
+/// providers missing from it score as `Community`.
+pub fn select(
+    policy: SelectionPolicy,
+    offers: &[OfferRecord],
+    job: &JobManifest,
+    reputation: &ReputationLedger,
+    trust_of: &dyn Fn(&Did) -> TrustTier,
+) -> Result<Selection, Error> {
+    if offers.is_empty() {
+        return Err(Error::NoOffers);
+    }
+    if policy == SelectionPolicy::Private && job.requirements.providers.is_empty() {
+        return Err(Error::Untrusted(
+            "the private policy requires the job to carry a provider allowlist".into(),
+        ));
+    }
+
+    let prices: Vec<f64> = offers
+        .iter()
+        .map(|o| amount(&o.offer.price))
+        .collect::<Result<_, _>>()?;
+    let durations: Vec<f64> = offers
+        .iter()
+        .map(|o| o.offer.expected_duration_ms as f64)
+        .collect();
+
+    let best_price = prices.iter().cloned().fold(f64::INFINITY, f64::min);
+    let best_duration = durations.iter().cloned().fold(f64::INFINITY, f64::min);
+
+    let w = policy.weights();
+    let mut ranked: Vec<ScoredOffer> = offers
+        .iter()
+        .enumerate()
+        .map(|(i, record)| {
+            let price = ratio(best_price, prices[i]);
+            let speed = ratio(best_duration, durations[i]);
+            let rep = reputation.score(&record.provider);
+            let trust = trust_score(trust_of(&record.provider));
+            ScoredOffer {
+                total: w.price * price + w.speed * speed + w.reputation * rep + w.trust * trust,
+                price,
+                speed,
+                reputation: rep,
+                trust,
+                record: record.clone(),
+            }
+        })
+        .collect();
+
+    // Highest score first; ties broken by provider DID so the answer never
+    // depends on iteration order.
+    ranked.sort_by(|a, b| {
+        b.total
+            .partial_cmp(&a.total)
+            .unwrap_or(std::cmp::Ordering::Equal)
+            .then_with(|| a.record.provider.as_str().cmp(b.record.provider.as_str()))
+    });
+
+    Ok(Selection { policy, ranked })
+}
+
+/// Score a lower-is-better quantity as `best / value`, in `0.0..=1.0`.
+///
+/// **Not** min-max normalization, and the difference matters. Min-max
+/// stretches whatever spread happens to be present across the full range,
+/// so with two offers a one-cent gap and a hundred-dollar gap both produce
+/// a 0.0-vs-1.0 split. Any price difference, however trivial, then
+/// outweighs every other dimension — which in practice means a provider
+/// that fails most of its jobs wins on being a cent cheaper, exactly the
+/// race to the bottom `Balanced` exists to avoid.
+///
+/// A ratio is proportional and scale-invariant: an offer 20% dearer than
+/// the best scores 0.83, whether the numbers are cents or thousands.
+///
+/// A free offer (`value <= 0`) dominates on that dimension rather than
+/// dividing by zero.
+fn ratio(best: f64, value: f64) -> f64 {
+    if value <= 0.0 {
+        return 1.0;
+    }
+    if !best.is_finite() || best <= 0.0 {
+        return 0.0;
+    }
+    (best / value).clamp(0.0, 1.0)
+}
+
+fn trust_score(tier: TrustTier) -> f64 {
+    match tier {
+        TrustTier::Community => 0.0,
+        TrustTier::Standard => 0.4,
+        TrustTier::Verified => 0.8,
+        TrustTier::Private | TrustTier::Enterprise => 1.0,
+    }
+}
+
+/// Parse a validated decimal amount for scoring.
+///
+/// Floats are fine *here* — this is a ranking heuristic, and a rounding
+/// error changes a preference rather than a correctness check. The
+/// within-cap test that actually gates an offer uses exact decimal
+/// comparison in [`crate::offers`].
+fn amount(m: &Money) -> Result<f64, Error> {
+    m.amount
+        .parse::<f64>()
+        .map_err(|_| Error::Untrusted(format!("unparseable amount {:?}", m.amount)))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::offers::OfferBook;
+    use crate::test_support::*;
+    use c0mpute_envelope::receipt::ValidationStatus;
+
+    /// Build a book from (seed, price, duration) triples.
+    fn book_of(job: &JobManifest, rows: &[(u8, &str, u64)]) -> Vec<OfferRecord> {
+        let mut book = OfferBook::for_job(job).unwrap();
+        for (seed, price, dur) in rows {
+            book.submit(&offer_from(*seed, job, price, *dur), job, &now())
+                .unwrap();
+        }
+        book.live(&now())
+    }
+
+    fn all_standard(_: &Did) -> TrustTier {
+        TrustTier::Standard
+    }
+
+    #[test]
+    fn cheapest_picks_the_lowest_price() {
+        let job = gpu_job();
+        let offers = book_of(&job, &[(7, "0.09", 5_000), (8, "0.02", 60_000)]);
+        let sel = select(
+            SelectionPolicy::Cheapest,
+            &offers,
+            &job,
+            &ReputationLedger::new(),
+            &all_standard,
+        )
+        .unwrap();
+        assert_eq!(sel.winner().record.offer.price.amount, "0.02");
+    }
+
+    #[test]
+    fn fastest_picks_the_shortest_quote_even_when_dearer() {
+        let job = gpu_job();
+        let offers = book_of(&job, &[(7, "0.09", 5_000), (8, "0.02", 60_000)]);
+        let sel = select(
+            SelectionPolicy::Fastest,
+            &offers,
+            &job,
+            &ReputationLedger::new(),
+            &all_standard,
+        )
+        .unwrap();
+        assert_eq!(sel.winner().record.offer.expected_duration_ms, 5_000);
+    }
+
+    #[test]
+    fn balanced_rejects_a_cheap_provider_with_a_bad_record() {
+        // The race-to-the-bottom case. Seed 8 is marginally cheaper and
+        // has failed most of its jobs; a pure price policy takes it and
+        // pays in retries.
+        let job = gpu_job();
+        let offers = book_of(&job, &[(7, "0.06", 12_000), (8, "0.05", 12_000)]);
+
+        let mut led = ReputationLedger::new();
+        for _ in 0..20 {
+            led.record(&receipt_for(7, 7, ValidationStatus::Accepted, 5_000, None))
+                .unwrap();
+        }
+        for _ in 0..20 {
+            led.record(&receipt_for(8, 8, ValidationStatus::Failed, 5_000, None))
+                .unwrap();
+        }
+
+        let cheap = select(
+            SelectionPolicy::Cheapest,
+            &offers,
+            &job,
+            &led,
+            &all_standard,
+        )
+        .unwrap();
+        assert_eq!(cheap.winner().record.provider, identity(8).did().clone());
+
+        let balanced = select(
+            SelectionPolicy::Balanced,
+            &offers,
+            &job,
+            &led,
+            &all_standard,
+        )
+        .unwrap();
+        assert_eq!(
+            balanced.winner().record.provider,
+            identity(7).did().clone(),
+            "balanced should pay 0.01 more to avoid a provider that fails"
+        );
+    }
+
+    #[test]
+    fn with_no_history_balanced_falls_back_to_price_and_speed() {
+        // Every provider scores a neutral 0.5, so reputation cancels and
+        // the cheaper, faster offer wins. A brand-new network must still
+        // make sensible choices.
+        let job = gpu_job();
+        let offers = book_of(&job, &[(7, "0.09", 30_000), (8, "0.02", 5_000)]);
+        let sel = select(
+            SelectionPolicy::Balanced,
+            &offers,
+            &job,
+            &ReputationLedger::new(),
+            &all_standard,
+        )
+        .unwrap();
+        assert_eq!(sel.winner().record.provider, identity(8).did().clone());
+    }
+
+    #[test]
+    fn trusted_prefers_a_higher_tier_over_a_lower_price() {
+        let job = gpu_job();
+        let offers = book_of(&job, &[(7, "0.09", 12_000), (8, "0.02", 12_000)]);
+        let seven = identity(7).did().clone();
+        let tiers = move |d: &Did| {
+            if *d == seven {
+                TrustTier::Verified
+            } else {
+                TrustTier::Community
+            }
+        };
+        let sel = select(
+            SelectionPolicy::Trusted,
+            &offers,
+            &job,
+            &ReputationLedger::new(),
+            &tiers,
+        )
+        .unwrap();
+        assert_eq!(sel.winner().record.provider, identity(7).did().clone());
+    }
+
+    #[test]
+    fn the_private_policy_demands_an_allowlist() {
+        let job = gpu_job(); // no allowlist
+        let offers = book_of(&job, &[(7, "0.05", 12_000)]);
+        assert!(matches!(
+            select(
+                SelectionPolicy::Private,
+                &offers,
+                &job,
+                &ReputationLedger::new(),
+                &all_standard
+            ),
+            Err(Error::Untrusted(_))
+        ));
+
+        let mut allowed = gpu_job();
+        allowed.requirements.providers = vec![identity(7).did().clone()];
+        let offers = book_of(&allowed, &[(7, "0.05", 12_000)]);
+        select(
+            SelectionPolicy::Private,
+            &offers,
+            &allowed,
+            &ReputationLedger::new(),
+            &all_standard,
+        )
+        .unwrap();
+    }
+
+    #[test]
+    fn an_empty_book_is_an_error_not_a_panic() {
+        let job = gpu_job();
+        assert!(matches!(
+            select(
+                SelectionPolicy::Balanced,
+                &[],
+                &job,
+                &ReputationLedger::new(),
+                &all_standard
+            ),
+            Err(Error::NoOffers)
+        ));
+    }
+
+    #[test]
+    fn a_single_offer_wins_without_dividing_by_a_zero_spread() {
+        let job = gpu_job();
+        let offers = book_of(&job, &[(7, "0.05", 12_000)]);
+        let sel = select(
+            SelectionPolicy::Balanced,
+            &offers,
+            &job,
+            &ReputationLedger::new(),
+            &all_standard,
+        )
+        .unwrap();
+        assert!(sel.winner().total.is_finite());
+        assert_eq!(sel.runners_up().len(), 0);
+    }
+
+    #[test]
+    fn identical_offers_rank_deterministically() {
+        let job = gpu_job();
+        let offers = book_of(&job, &[(7, "0.05", 12_000), (8, "0.05", 12_000)]);
+        let run = || {
+            select(
+                SelectionPolicy::Balanced,
+                &offers,
+                &job,
+                &ReputationLedger::new(),
+                &all_standard,
+            )
+            .unwrap()
+            .winner()
+            .record
+            .provider
+            .clone()
+        };
+        assert_eq!(run(), run());
+
+        // And reversing the input does not change the answer.
+        let mut reversed = offers.clone();
+        reversed.reverse();
+        let other = select(
+            SelectionPolicy::Balanced,
+            &reversed,
+            &job,
+            &ReputationLedger::new(),
+            &all_standard,
+        )
+        .unwrap();
+        assert_eq!(run(), other.winner().record.provider);
+    }
+
+    #[test]
+    fn ranking_keeps_every_candidate_for_inspection() {
+        let job = gpu_job();
+        let offers = book_of(
+            &job,
+            &[(7, "0.09", 5_000), (8, "0.02", 60_000), (9, "0.05", 9_000)],
+        );
+        let sel = select(
+            SelectionPolicy::Balanced,
+            &offers,
+            &job,
+            &ReputationLedger::new(),
+            &all_standard,
+        )
+        .unwrap();
+        assert_eq!(sel.ranked.len(), 3);
+        assert_eq!(sel.runners_up().len(), 2);
+        assert!(sel.winner().total >= sel.ranked[1].total);
+        assert!(sel.explain().contains("won under balanced"));
+    }
+
+    #[test]
+    fn policy_names_round_trip() {
+        for p in [
+            SelectionPolicy::Cheapest,
+            SelectionPolicy::Fastest,
+            SelectionPolicy::Balanced,
+            SelectionPolicy::Trusted,
+            SelectionPolicy::Private,
+        ] {
+            assert_eq!(SelectionPolicy::parse(p.as_str()).unwrap(), p);
+        }
+        assert!(SelectionPolicy::parse("whatever").is_err());
+        assert_eq!(SelectionPolicy::default(), SelectionPolicy::Balanced);
+    }
+}

--- a/node/crates/c0mpute-market/src/reputation.rs
+++ b/node/crates/c0mpute-market/src/reputation.rs
@@ -1,0 +1,367 @@
+//! Reputation, derived from signed receipts.
+//!
+//! There is no global score and no table anyone can edit. A node that has
+//! collected receipts computes provider statistics for itself, and two
+//! nodes weighting them differently are both correct. Feed the same
+//! receipts to a fresh ledger and you get the same numbers back — which is
+//! what makes a provider's record survive us, and survive anyone deciding
+//! they do not like it.
+//!
+//! ## A new provider is not a bad provider
+//!
+//! Success rate is smoothed toward a neutral prior rather than computed
+//! raw. Without that, a provider's first job is scored on a 0/0 record —
+//! either 0.0, which makes joining impossible, or 1.0 after one success,
+//! which makes a fresh key better than a provider with a thousand jobs and
+//! two failures. Smoothing makes the first few jobs cheap to price and the
+//! record meaningful once it exists.
+
+use std::collections::HashMap;
+
+use c0mpute_envelope::receipt::ValidationStatus;
+use c0mpute_envelope::{Did, Envelope, Offer, Receipt};
+
+use crate::Error;
+
+/// Strength of the neutral prior, in imaginary jobs. Two is the standard
+/// Laplace choice: one imaginary success and one imaginary failure, so an
+/// unknown provider scores exactly 0.5.
+const PRIOR_JOBS: f64 = 2.0;
+const PRIOR_SUCCESSES: f64 = 1.0;
+
+/// What one node has observed about one provider.
+#[derive(Clone, Debug, Default, PartialEq, Eq)]
+pub struct ProviderStats {
+    pub completed: u32,
+    pub failed: u32,
+    pub rejected: u32,
+    pub disputed: u32,
+    /// Summed wall-clock execution time over jobs where we hold both the
+    /// offer and the receipt.
+    pub actual_ms: u64,
+    /// Summed quoted duration over those same jobs.
+    pub quoted_ms: u64,
+    pub quoted_samples: u32,
+}
+
+impl ProviderStats {
+    /// Every receipt seen for this provider.
+    pub fn jobs(&self) -> u32 {
+        self.completed + self.failed + self.rejected + self.disputed
+    }
+
+    /// Smoothed success rate in `0.0..=1.0`. An unseen provider scores 0.5.
+    pub fn success_rate(&self) -> f64 {
+        let good = f64::from(self.completed) + PRIOR_SUCCESSES;
+        let total = f64::from(self.jobs()) + PRIOR_JOBS;
+        good / total
+    }
+
+    /// How well quotes predicted reality: `quoted / actual`.
+    ///
+    /// `1.0` means dead on, above means the provider beat its estimates,
+    /// below means it overran them. `None` until we hold a matched
+    /// offer/receipt pair.
+    ///
+    /// Hard to game: the quote is signed before the work and the receipt
+    /// after it, and both are cited by hash.
+    pub fn quote_accuracy(&self) -> Option<f64> {
+        if self.quoted_samples == 0 || self.actual_ms == 0 {
+            return None;
+        }
+        Some(self.quoted_ms as f64 / self.actual_ms as f64)
+    }
+
+    /// A single 0..1 summary for scoring. Success rate, with disputes
+    /// weighted more heavily than plain failures: a job that failed is a
+    /// bad day, a job the buyer disputed is a disagreement about whether
+    /// the work was done at all.
+    pub fn score(&self) -> f64 {
+        let base = self.success_rate();
+        let penalty = if self.jobs() == 0 {
+            0.0
+        } else {
+            0.5 * f64::from(self.disputed) / f64::from(self.jobs())
+        };
+        (base - penalty).clamp(0.0, 1.0)
+    }
+}
+
+/// Per-provider statistics accumulated from receipts this node holds.
+#[derive(Debug, Default)]
+pub struct ReputationLedger {
+    by_provider: HashMap<String, ProviderStats>,
+}
+
+impl ReputationLedger {
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Record a signed receipt.
+    ///
+    /// Verifies before counting: an unverified receipt is an unsupported
+    /// claim about someone else's record, and counting one would recreate
+    /// exactly the "trust me" property this design exists to remove.
+    pub fn record(&mut self, receipt: &Envelope<Receipt>) -> Result<(), Error> {
+        let r = receipt.open().map_err(Error::Envelope)?;
+        // The receipt names its provider, and the envelope proves who
+        // signed it. A receipt signed by someone other than the provider
+        // or the validator is not evidence about the provider.
+        if receipt.signer != r.provider {
+            return Err(Error::Untrusted(format!(
+                "receipt for provider {} was signed by {}",
+                r.provider, receipt.signer
+            )));
+        }
+
+        let s = self.entry(&r.provider);
+        match r.validation.status {
+            ValidationStatus::Accepted => s.completed += 1,
+            ValidationStatus::Failed => s.failed += 1,
+            ValidationStatus::Rejected => s.rejected += 1,
+            ValidationStatus::Disputed => s.disputed += 1,
+        }
+        Ok(())
+    }
+
+    /// Record a receipt together with the offer that priced it, which also
+    /// yields quote accuracy.
+    ///
+    /// The receipt must cite this exact offer by hash. Without that check
+    /// a provider could be credited for beating an estimate it never gave.
+    pub fn record_against_offer(
+        &mut self,
+        receipt: &Envelope<Receipt>,
+        offer: &Envelope<Offer>,
+    ) -> Result<(), Error> {
+        let r = receipt.open().map_err(Error::Envelope)?;
+        let o = offer.open().map_err(Error::Envelope)?;
+        let offer_hash = offer.content_hash().map_err(Error::Envelope)?;
+        if r.offer != offer_hash {
+            return Err(Error::Untrusted(format!(
+                "receipt cites offer {} but was given offer {offer_hash}",
+                r.offer
+            )));
+        }
+        if receipt.signer != offer.signer {
+            return Err(Error::Untrusted(
+                "receipt and offer were signed by different identities".into(),
+            ));
+        }
+
+        let actual = r.duration_ms().max(0) as u64;
+        let quoted = o.expected_duration_ms;
+        self.record(receipt)?;
+
+        let s = self.entry(&receipt.signer.clone());
+        s.actual_ms += actual;
+        s.quoted_ms += quoted;
+        s.quoted_samples += 1;
+        Ok(())
+    }
+
+    /// Statistics for a provider. An unseen provider gets the default —
+    /// a 0.5 score, not a zero.
+    pub fn stats(&self, provider: &Did) -> ProviderStats {
+        self.by_provider
+            .get(provider.as_str())
+            .cloned()
+            .unwrap_or_default()
+    }
+
+    /// Convenience: the 0..1 score used by scoring policies.
+    pub fn score(&self, provider: &Did) -> f64 {
+        self.stats(provider).score()
+    }
+
+    /// How many providers we hold any history for.
+    pub fn len(&self) -> usize {
+        self.by_provider.len()
+    }
+
+    pub fn is_empty(&self) -> bool {
+        self.by_provider.is_empty()
+    }
+
+    fn entry(&mut self, provider: &Did) -> &mut ProviderStats {
+        self.by_provider
+            .entry(provider.as_str().to_string())
+            .or_default()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::test_support::*;
+
+    #[test]
+    fn an_unseen_provider_scores_neutral_not_zero() {
+        let led = ReputationLedger::new();
+        let (did, _) = gpu_provider();
+        assert_eq!(led.stats(&did), ProviderStats::default());
+        assert!((led.score(&did) - 0.5).abs() < 1e-9);
+    }
+
+    #[test]
+    fn one_success_does_not_outrank_a_long_good_record() {
+        // The reason smoothing exists: a fresh key with a single success
+        // must not be worth more than a provider with a real history.
+        let mut led = ReputationLedger::new();
+        let newcomer = identity(30).did().clone();
+        record_n(&mut led, 30, ValidationStatus::Accepted, 1);
+
+        let veteran = identity(31).did().clone();
+        record_n(&mut led, 31, ValidationStatus::Accepted, 200);
+        record_n(&mut led, 31, ValidationStatus::Failed, 2);
+
+        assert!(
+            led.score(&veteran) > led.score(&newcomer),
+            "veteran {} should beat newcomer {}",
+            led.score(&veteran),
+            led.score(&newcomer)
+        );
+    }
+
+    #[test]
+    fn failures_lower_the_score() {
+        let mut led = ReputationLedger::new();
+        let did = identity(32).did().clone();
+        record_n(&mut led, 32, ValidationStatus::Accepted, 10);
+        let good = led.score(&did);
+        record_n(&mut led, 32, ValidationStatus::Failed, 10);
+        assert!(led.score(&did) < good);
+    }
+
+    #[test]
+    fn a_dispute_costs_more_than_a_failure() {
+        let mut led_f = ReputationLedger::new();
+        record_n(&mut led_f, 33, ValidationStatus::Accepted, 10);
+        record_n(&mut led_f, 33, ValidationStatus::Failed, 2);
+
+        let mut led_d = ReputationLedger::new();
+        record_n(&mut led_d, 34, ValidationStatus::Accepted, 10);
+        record_n(&mut led_d, 34, ValidationStatus::Disputed, 2);
+
+        assert!(
+            led_d.score(&identity(34).did().clone()) < led_f.score(&identity(33).did().clone())
+        );
+    }
+
+    #[test]
+    fn failures_are_counted_which_is_the_point_of_signing_them() {
+        let mut led = ReputationLedger::new();
+        record_n(&mut led, 35, ValidationStatus::Failed, 3);
+        let s = led.stats(&identity(35).did().clone());
+        assert_eq!(s.failed, 3);
+        assert_eq!(s.jobs(), 3);
+        assert!(s.score() < 0.5);
+    }
+
+    #[test]
+    fn a_receipt_signed_by_someone_else_is_not_evidence() {
+        // Trivially forgeable reputation would otherwise be one signature
+        // away: sign a glowing receipt about a competitor, or about
+        // yourself under another provider's name.
+        let mut led = ReputationLedger::new();
+        let receipt = receipt_for(
+            /* claimed provider */ 7,
+            /* signed by */ 8,
+            ValidationStatus::Accepted,
+            12_000,
+            None,
+        );
+        assert!(matches!(led.record(&receipt), Err(Error::Untrusted(_))));
+        assert!(led.is_empty());
+    }
+
+    #[test]
+    fn a_tampered_receipt_is_rejected() {
+        let mut led = ReputationLedger::new();
+        let mut receipt = receipt_for(7, 7, ValidationStatus::Failed, 12_000, None);
+        receipt.payload.validation.status = ValidationStatus::Accepted;
+        assert!(led.record(&receipt).is_err());
+        assert!(led.is_empty());
+    }
+
+    #[test]
+    fn quote_accuracy_needs_a_matching_offer() {
+        let mut led = ReputationLedger::new();
+        let job = gpu_job();
+        let offer = offer_from(7, &job, "0.05", 10_000);
+        let receipt = receipt_for(
+            7,
+            7,
+            ValidationStatus::Accepted,
+            8_000,
+            Some(offer.content_hash().unwrap()),
+        );
+
+        led.record_against_offer(&receipt, &offer).unwrap();
+        let s = led.stats(&identity(7).did().clone());
+        assert_eq!(s.completed, 1);
+        // Quoted 10s, took 8s: beat the estimate, ratio 1.25.
+        assert!((s.quote_accuracy().unwrap() - 1.25).abs() < 1e-9);
+    }
+
+    #[test]
+    fn credit_cannot_be_claimed_against_an_unrelated_offer() {
+        let mut led = ReputationLedger::new();
+        let job = gpu_job();
+        let real = offer_from(7, &job, "0.05", 10_000);
+        let other = offer_from(7, &job, "0.09", 999_000);
+        let receipt = receipt_for(
+            7,
+            7,
+            ValidationStatus::Accepted,
+            8_000,
+            Some(real.content_hash().unwrap()),
+        );
+
+        // Pairing the receipt with a slower quote would manufacture a
+        // flattering accuracy number.
+        assert!(matches!(
+            led.record_against_offer(&receipt, &other),
+            Err(Error::Untrusted(_))
+        ));
+        assert!(led.is_empty());
+    }
+
+    #[test]
+    fn stats_rebuild_identically_from_the_same_receipts() {
+        // The portability claim: reputation is derived, so a node that
+        // loses its ledger and replays its receipt log lands in exactly
+        // the same place. Order must not matter either.
+        let job = gpu_job();
+        let offer = offer_from(7, &job, "0.05", 10_000);
+        let oh = offer.content_hash().unwrap();
+        let receipts = vec![
+            receipt_for(7, 7, ValidationStatus::Accepted, 8_000, Some(oh.clone())),
+            receipt_for(7, 7, ValidationStatus::Failed, 1_000, None),
+            receipt_for(7, 7, ValidationStatus::Accepted, 9_000, None),
+        ];
+
+        let mut a = ReputationLedger::new();
+        for r in &receipts {
+            let _ = a.record(r);
+        }
+
+        let mut b = ReputationLedger::new();
+        for r in receipts.iter().rev() {
+            let _ = b.record(r);
+        }
+
+        let did = identity(7).did().clone();
+        assert_eq!(a.stats(&did), b.stats(&did));
+        assert_eq!(a.stats(&did).completed, 2);
+        assert_eq!(a.stats(&did).failed, 1);
+    }
+
+    fn record_n(led: &mut ReputationLedger, seed: u8, status: ValidationStatus, n: u32) {
+        for _ in 0..n {
+            led.record(&receipt_for(seed, seed, status, 5_000, None))
+                .unwrap();
+        }
+    }
+}

--- a/node/crates/c0mpute-market/src/test_support.rs
+++ b/node/crates/c0mpute-market/src/test_support.rs
@@ -1,0 +1,188 @@
+//! Fixtures shared by this crate's unit tests.
+//!
+//! Deterministic by construction: identities come from fixed seeds and
+//! timestamps are literals, so a scoring change shows up as a diff in the
+//! chosen provider rather than as an intermittent failure.
+
+use c0mpute_envelope::advert::{
+    CpuSpec, Disclosure, ProviderAdvert, ProviderCapabilities, ProviderTrust, Rate,
+};
+use c0mpute_envelope::job::{
+    Bound, Economics, Execution, GpuRequirement, Isolation, JobManifest, JobOutput, Requirements,
+    WorkloadRef,
+};
+use c0mpute_envelope::receipt::{SettlementRecord, ValidationOutcome, ValidationStatus};
+use c0mpute_envelope::{
+    ContentHash, Did, Envelope, GpuSpec, Money, Offer, Receipt, SettlementAdapter, SigningIdentity,
+    Timestamp, TrustTier, ValidationPolicy,
+};
+
+pub const WORKLOAD: &str = "infernet.inference";
+
+pub fn identity(seed: u8) -> SigningIdentity {
+    SigningIdentity::from_seed(&[seed; 32])
+}
+
+pub fn ts(s: &str) -> Timestamp {
+    Timestamp::parse(s).unwrap()
+}
+
+/// "Now" for every fixture. The job below opens at 16:00 and closes at
+/// 16:10, so this sits comfortably inside the window.
+pub fn now() -> Timestamp {
+    ts("2026-09-06T16:00:05.000Z")
+}
+
+pub fn gpu(vram_gib: u32, count: u32, features: &[&str]) -> GpuSpec {
+    GpuSpec {
+        vendor: "nvidia".into(),
+        family: Some("ada".into()),
+        vram_gib,
+        features: features.iter().map(|s| (*s).to_string()).collect(),
+        count,
+    }
+}
+
+/// A provider that satisfies [`gpu_job`].
+pub fn gpu_provider() -> (Did, ProviderAdvert) {
+    provider_seeded(7)
+}
+
+/// Same shape, distinct identity — for tests that need a market.
+pub fn provider_seeded(seed: u8) -> (Did, ProviderAdvert) {
+    let did = identity(seed).did().clone();
+    let advert = ProviderAdvert {
+        sequence: 1,
+        issued_at: ts("2026-09-06T16:00:00.000Z"),
+        expires_at: ts("2026-09-06T16:10:00.000Z"),
+        capabilities: ProviderCapabilities {
+            cpu: CpuSpec {
+                arch: "x86_64".into(),
+                cores: 32,
+            },
+            memory_gib: 128,
+            gpus: vec![gpu(24, 1, &["cuda"])],
+            storage_gib: 512,
+            bandwidth_mbps: 1000,
+            workloads: vec![WORKLOAD.into(), "transcode.ffmpeg".into()],
+        },
+        pricing: vec![Rate {
+            workload: WORKLOAD.into(),
+            unit: "1m-output-tokens".into(),
+            price: Money::new("0.60", "USD"),
+        }],
+        trust: ProviderTrust {
+            tier: TrustTier::Standard,
+            credentials: vec![],
+        },
+        disclosure: Some(Disclosure {
+            region: Some("us-west".into()),
+            country: None,
+            asn: Some(64500 + u32::from(seed)),
+        }),
+    };
+    (did, advert)
+}
+
+pub fn sealed_advert(seed: u8) -> (Did, Envelope<ProviderAdvert>) {
+    let id = identity(seed);
+    let (did, advert) = provider_seeded(seed);
+    (did, Envelope::seal(&id, advert).unwrap())
+}
+
+/// A job requiring one 24 GiB CUDA GPU, capped at $0.10.
+pub fn gpu_job() -> JobManifest {
+    JobManifest {
+        workload: WorkloadRef {
+            type_id: WORKLOAD.into(),
+            version: None,
+        },
+        requester: identity(1).did().clone(),
+        requirements: Requirements {
+            gpu: Some(GpuRequirement {
+                count: 1,
+                vram_gib: Some(Bound::at_least(24)),
+                features: vec!["cuda".into()],
+            }),
+            cpu_cores: None,
+            memory_gib: Some(Bound::at_least(32)),
+            region: vec![],
+            trust_tier: TrustTier::Standard,
+            providers: vec![],
+        },
+        input: None,
+        execution: Execution {
+            timeout_seconds: 120,
+            retry: 0,
+            isolation: Isolation::Container,
+            runtime_digest: None,
+            network: false,
+        },
+        economics: Economics {
+            max_price: Money::new("0.10", "USD"),
+            settlement: SettlementAdapter::coinpay(),
+            escrow: true,
+        },
+        validation: ValidationPolicy::default(),
+        output: JobOutput::default(),
+        announced_at: ts("2026-09-06T16:00:00.000Z"),
+        deadline: ts("2026-09-06T16:10:00.000Z"),
+    }
+}
+
+/// An offer for `job` at `price`, taking `duration_ms`.
+pub fn offer_from(seed: u8, job: &JobManifest, price: &str, duration_ms: u64) -> Envelope<Offer> {
+    let offer = Offer {
+        job: job.id().unwrap(),
+        price: Money::new(price, "USD"),
+        expected_duration_ms: duration_ms,
+        start_before: ts("2026-09-06T16:01:00.000Z"),
+        expires_at: ts("2026-09-06T16:00:30.000Z"),
+        capability_advert: Some(ContentHash::of(b"advert")),
+        coordinator: false,
+    };
+    Envelope::seal(&identity(seed), offer).unwrap()
+}
+
+/// A sealed receipt.
+///
+/// `claimed` is the provider the receipt names; `signer` is who actually
+/// signs it. They are separate parameters so tests can build the forgery
+/// case — a receipt about someone else's work — as easily as the honest one.
+pub fn receipt_for(
+    claimed: u8,
+    signer: u8,
+    status: ValidationStatus,
+    duration_ms: i64,
+    offer_hash: Option<ContentHash>,
+) -> Envelope<Receipt> {
+    let started = ts("2026-09-06T16:01:00.000Z");
+    let completed = Timestamp::from_unix_ms(started.unix_ms() + duration_ms).unwrap();
+    let accepted = status == ValidationStatus::Accepted;
+
+    let receipt = Receipt {
+        job: gpu_job().id().unwrap(),
+        buyer: identity(1).did().clone(),
+        provider: identity(claimed).did().clone(),
+        validator: None,
+        workload: WORKLOAD.into(),
+        offer: offer_hash.unwrap_or_else(|| ContentHash::of(b"some offer")),
+        input_hash: Some(ContentHash::of(b"in")),
+        output_hash: accepted.then(|| ContentHash::of(b"out")),
+        runtime_hash: Some(ContentHash::of(b"runtime")),
+        started_at: started,
+        completed_at: completed,
+        price: Money::new("0.05", "USD"),
+        validation: ValidationOutcome {
+            policy: ValidationPolicy::default(),
+            status,
+            detail: None,
+        },
+        settlement: SettlementRecord {
+            adapter: SettlementAdapter::coinpay(),
+            reference: accepted.then(|| "cp_rcpt_test".to_string()),
+            settled: accepted,
+        },
+    };
+    Envelope::seal(&identity(signer), receipt).unwrap()
+}

--- a/node/crates/c0mpute-market/tests/gateway_none.rs
+++ b/node/crates/c0mpute-market/tests/gateway_none.rs
@@ -1,0 +1,469 @@
+//! The full market chain, with nothing in the middle.
+//!
+//! This is the protocol half of the v2 direction's `--gateway none`
+//! release gate (§32, Test A) and of Test B, "no shared database". A buyer
+//! and a provider are constructed as two independent parties that share
+//! **no memory, no database, and no service** — every fact that crosses
+//! between them crosses as JSON bytes through [`Wire`], the way it would
+//! come off a gossip topic or a file.
+//!
+//! What this does prove:
+//!
+//! - discovery, quoting, award, execution and settlement need no third
+//!   party to be *believed*;
+//! - a hostile courier — an indexer, a relay, anything that touches the
+//!   bytes in transit — can drop or delay messages but cannot forge them;
+//! - a fourth party who saw none of it, holding only the JSON, reaches the
+//!   same conclusions.
+//!
+//! What it does **not** prove: that the transport works. There is no
+//! libp2p here, no DHT, no NAT traversal. Those are the rest of Phase 2,
+//! and the real `--gateway none` gate needs them. This test pins the layer
+//! underneath, so that when the transport lands the only new question is
+//! whether packets arrive.
+
+use c0mpute_envelope::advert::{
+    CpuSpec, Disclosure, ProviderAdvert, ProviderCapabilities, ProviderTrust, Rate,
+};
+use c0mpute_envelope::job::{
+    Bound, Economics, Execution, GpuRequirement, Isolation, JobManifest, JobOutput, Requirements,
+    WorkloadRef,
+};
+use c0mpute_envelope::receipt::{SettlementRecord, ValidationOutcome, ValidationStatus};
+use c0mpute_envelope::{
+    ContentHash, Envelope, GpuSpec, Money, Offer, Receipt, ReceiptAcceptance, SettlementAdapter,
+    SigningIdentity, Timestamp, TrustTier, ValidationPolicy,
+};
+use c0mpute_market::{OfferBook, ProviderDirectory, ReputationLedger, SelectionPolicy, select};
+
+const WORKLOAD: &str = "infernet.inference";
+
+/// The only thing the two parties share: bytes.
+///
+/// Deliberately not a channel of typed values. Everything is serialized
+/// and re-parsed, so nothing can pass between the parties except what
+/// would survive a real hop — no shared allocation, no implicit trust.
+#[derive(Default)]
+struct Wire {
+    frames: Vec<String>,
+}
+
+impl Wire {
+    fn send<T: c0mpute_envelope::Payload>(&mut self, envelope: &Envelope<T>) {
+        self.frames.push(envelope.to_canonical_json().unwrap());
+    }
+
+    fn last(&self) -> &str {
+        self.frames.last().expect("nothing sent")
+    }
+}
+
+fn ts(s: &str) -> Timestamp {
+    Timestamp::parse(s).unwrap()
+}
+
+/// The advert a provider publishes. It does not name its own signer —
+/// the envelope does — so this needs no identity to build.
+fn advert() -> ProviderAdvert {
+    ProviderAdvert {
+        sequence: 1,
+        issued_at: ts("2026-09-06T16:00:00.000Z"),
+        expires_at: ts("2026-09-06T16:10:00.000Z"),
+        capabilities: ProviderCapabilities {
+            cpu: CpuSpec {
+                arch: "x86_64".into(),
+                cores: 32,
+            },
+            memory_gib: 128,
+            gpus: vec![GpuSpec {
+                vendor: "nvidia".into(),
+                family: Some("ada".into()),
+                vram_gib: 24,
+                features: vec!["cuda".into()],
+                count: 1,
+            }],
+            storage_gib: 512,
+            bandwidth_mbps: 1000,
+            workloads: vec![WORKLOAD.into()],
+        },
+        pricing: vec![Rate {
+            workload: WORKLOAD.into(),
+            unit: "1m-output-tokens".into(),
+            price: Money::new("0.60", "USD"),
+        }],
+        trust: ProviderTrust {
+            tier: TrustTier::Standard,
+            credentials: vec![],
+        },
+        disclosure: Some(Disclosure {
+            region: Some("us-west".into()),
+            country: None,
+            asn: None,
+        }),
+    }
+}
+
+fn job_for(buyer: &SigningIdentity) -> JobManifest {
+    JobManifest {
+        workload: WorkloadRef {
+            type_id: WORKLOAD.into(),
+            version: Some(">=1 <2".into()),
+        },
+        requester: buyer.did().clone(),
+        requirements: Requirements {
+            gpu: Some(GpuRequirement {
+                count: 1,
+                vram_gib: Some(Bound::at_least(24)),
+                features: vec!["cuda".into()],
+            }),
+            cpu_cores: None,
+            memory_gib: Some(Bound::at_least(32)),
+            region: vec!["us-west".into()],
+            trust_tier: TrustTier::Standard,
+            providers: vec![],
+        },
+        input: Some(c0mpute_envelope::job::JobInput {
+            reference: ContentHash::of(b"prompts.jsonl"),
+            encryption: None,
+            bytes: Some(4096),
+        }),
+        execution: Execution {
+            timeout_seconds: 120,
+            retry: 0,
+            isolation: Isolation::Container,
+            runtime_digest: Some(ContentHash::of(b"runtime image")),
+            network: false,
+        },
+        economics: Economics {
+            max_price: Money::new("0.10", "USD"),
+            settlement: SettlementAdapter::coinpay(),
+            escrow: true,
+        },
+        validation: ValidationPolicy::default(),
+        output: JobOutput::default(),
+        announced_at: ts("2026-09-06T16:00:00.000Z"),
+        deadline: ts("2026-09-06T16:10:00.000Z"),
+    }
+}
+
+#[test]
+fn a_job_completes_with_no_third_party_anywhere() {
+    let now = ts("2026-09-06T16:00:05.000Z");
+
+    // Two parties. Separate keys, separate state, nothing shared.
+    let buyer = SigningIdentity::from_seed(&[0x11; 32]);
+    let provider = SigningIdentity::from_seed(&[0x77; 32]);
+
+    let mut buyer_directory = ProviderDirectory::new();
+    let mut buyer_reputation = ReputationLedger::new();
+    let mut wire = Wire::default();
+
+    // ── 1. the provider advertises ───────────────────────────────────
+    let advert = Envelope::seal(&provider, advert()).unwrap();
+    wire.send(&advert);
+
+    // The buyer learns of it from bytes, and verifies before believing.
+    let heard: Envelope<ProviderAdvert> = Envelope::from_json(wire.last()).unwrap();
+    buyer_directory.insert(&heard, &now).unwrap();
+    assert_eq!(buyer_directory.len(), 1);
+
+    // ── 2. the buyer announces a job ─────────────────────────────────
+    let job = job_for(&buyer);
+    let job_id = job.id().unwrap();
+    let sealed_job = Envelope::seal(&buyer, job.clone()).unwrap();
+    wire.send(&sealed_job);
+
+    // The buyer's own client does the matching. No matcher was consulted.
+    let eligible = buyer_directory.eligible(&job, &now);
+    assert_eq!(eligible.len(), 1, "the provider qualifies");
+    assert_eq!(eligible[0].provider, *provider.did());
+
+    // ── 3. the provider quotes ───────────────────────────────────────
+    let seen_job: Envelope<JobManifest> = Envelope::from_json(wire.last()).unwrap();
+    let seen = seen_job.open().unwrap();
+    assert!(
+        seen.signed_by(&seen_job.signer),
+        "the manifest names the identity that signed it"
+    );
+
+    let offer = Offer {
+        job: seen.id().unwrap(),
+        price: Money::new("0.042", "USD"),
+        expected_duration_ms: 12_000,
+        start_before: ts("2026-09-06T16:01:00.000Z"),
+        expires_at: ts("2026-09-06T16:00:30.000Z"),
+        capability_advert: Some(advert.content_hash().unwrap()),
+        coordinator: false,
+    };
+    let sealed_offer = Envelope::seal(&provider, offer).unwrap();
+    wire.send(&sealed_offer);
+
+    // ── 4. the buyer collects and selects ────────────────────────────
+    let mut book = OfferBook::for_job(&job).unwrap();
+    let heard_offer: Envelope<Offer> = Envelope::from_json(wire.last()).unwrap();
+    book.submit(&heard_offer, &job, &now).unwrap();
+
+    let eligible_dids: Vec<_> = eligible.iter().map(|r| r.provider.clone()).collect();
+    let candidates = book.live_from(&eligible_dids, &now);
+    let selection = select(
+        SelectionPolicy::Balanced,
+        &candidates,
+        &job,
+        &buyer_reputation,
+        &|_| TrustTier::Standard,
+    )
+    .unwrap();
+
+    let winner = selection.winner();
+    assert_eq!(winner.record.provider, *provider.did());
+    assert_eq!(winner.record.offer.price.amount, "0.042");
+
+    // The quote is tied back to the capabilities it was made against.
+    assert_eq!(
+        winner.record.offer.capability_advert.as_ref().unwrap(),
+        &advert.content_hash().unwrap()
+    );
+
+    // ── 5. the provider runs the work and signs for it ───────────────
+    let receipt = Receipt {
+        job: job_id.clone(),
+        buyer: buyer.did().clone(),
+        provider: provider.did().clone(),
+        validator: None,
+        workload: WORKLOAD.into(),
+        offer: sealed_offer.content_hash().unwrap(),
+        input_hash: Some(ContentHash::of(b"prompts.jsonl")),
+        output_hash: Some(ContentHash::of(b"completions.jsonl")),
+        runtime_hash: Some(ContentHash::of(b"runtime image")),
+        started_at: ts("2026-09-06T16:01:00.000Z"),
+        completed_at: ts("2026-09-06T16:01:12.000Z"),
+        price: winner.record.offer.price.clone(),
+        validation: ValidationOutcome {
+            policy: ValidationPolicy::default(),
+            status: ValidationStatus::Accepted,
+            detail: None,
+        },
+        settlement: SettlementRecord {
+            adapter: SettlementAdapter::coinpay(),
+            reference: Some("cp_rcpt_demo".into()),
+            settled: true,
+        },
+    };
+    let sealed_receipt = Envelope::seal(&provider, receipt).unwrap();
+    wire.send(&sealed_receipt);
+
+    // ── 6. the buyer checks and countersigns ─────────────────────────
+    let heard_receipt: Envelope<Receipt> = Envelope::from_json(wire.last()).unwrap();
+    let r = heard_receipt.open().unwrap();
+
+    // The two facts a buyer must be able to establish alone.
+    assert_eq!(r.job, job_id, "receipt is for the job we announced");
+    assert_eq!(
+        r.offer,
+        sealed_offer.content_hash().unwrap(),
+        "receipt cites the offer we accepted"
+    );
+    assert_eq!(
+        r.price, winner.record.offer.price,
+        "charged exactly what was quoted"
+    );
+    assert!(r.is_success());
+
+    let acceptance = Envelope::seal(
+        &buyer,
+        ReceiptAcceptance {
+            receipt: heard_receipt.content_hash().unwrap(),
+            accepted: true,
+            signed_at: ts("2026-09-06T16:01:20.000Z"),
+            reason: None,
+        },
+    )
+    .unwrap();
+    wire.send(&acceptance);
+
+    // ── 7. reputation, derived locally ───────────────────────────────
+    buyer_reputation
+        .record_against_offer(&heard_receipt, &sealed_offer)
+        .unwrap();
+    let stats = buyer_reputation.stats(provider.did());
+    assert_eq!(stats.completed, 1);
+    // Quoted 12s, took 12s.
+    assert!((stats.quote_accuracy().unwrap() - 1.0).abs() < 1e-9);
+
+    // ── 8. a fourth party, holding only the bytes ────────────────────
+    // Never online, no database, no access to either party's state.
+    let auditor_advert: Envelope<ProviderAdvert> = Envelope::from_json(&wire.frames[0]).unwrap();
+    let auditor_job: Envelope<JobManifest> = Envelope::from_json(&wire.frames[1]).unwrap();
+    let auditor_offer: Envelope<Offer> = Envelope::from_json(&wire.frames[2]).unwrap();
+    let auditor_receipt: Envelope<Receipt> = Envelope::from_json(&wire.frames[3]).unwrap();
+    let auditor_acceptance: Envelope<ReceiptAcceptance> =
+        Envelope::from_json(&wire.frames[4]).unwrap();
+
+    auditor_advert.open().unwrap();
+    let aj = auditor_job.open().unwrap();
+    let ao = auditor_offer.open().unwrap();
+    let ar = auditor_receipt.open().unwrap();
+    let aa = auditor_acceptance.open().unwrap();
+
+    assert_eq!(ao.job, aj.id().unwrap());
+    assert_eq!(ar.offer, auditor_offer.content_hash().unwrap());
+    assert_eq!(ar.price, ao.price, "quoted price equals charged price");
+    assert_eq!(aa.receipt, auditor_receipt.content_hash().unwrap());
+    assert_eq!(auditor_offer.signer, auditor_receipt.signer);
+    assert_eq!(auditor_acceptance.signer, *buyer.did());
+}
+
+#[test]
+fn a_hostile_courier_can_delay_but_not_forge() {
+    let now = ts("2026-09-06T16:00:05.000Z");
+    let buyer = SigningIdentity::from_seed(&[0x11; 32]);
+    let provider = SigningIdentity::from_seed(&[0x77; 32]);
+    let job = job_for(&buyer);
+
+    // Everything an intermediary sits in front of, rewritten in its
+    // favour. Each attempt is a realistic thing a malicious indexer,
+    // relay or gateway would try.
+    let mut directory = ProviderDirectory::new();
+
+    // (a) inflate a provider's capabilities to win more work
+    let mut fat = Envelope::seal(&provider, advert()).unwrap();
+    fat.payload.capabilities.gpus[0].vram_gib = 80;
+    assert!(directory.insert(&fat, &now).is_err());
+
+    // (b) undercut a quote to steer the award
+    let honest_offer = Offer {
+        job: job.id().unwrap(),
+        price: Money::new("0.042", "USD"),
+        expected_duration_ms: 12_000,
+        start_before: ts("2026-09-06T16:01:00.000Z"),
+        expires_at: ts("2026-09-06T16:00:30.000Z"),
+        capability_advert: None,
+        coordinator: false,
+    };
+    let mut cut = Envelope::seal(&provider, honest_offer).unwrap();
+    cut.payload.price = Money::new("0.001", "USD");
+    let mut book = OfferBook::for_job(&job).unwrap();
+    assert!(book.submit(&cut, &job, &now).is_err());
+
+    // (c) re-point an offer at a different, more expensive job
+    let mut dearer = job_for(&buyer);
+    dearer.economics.max_price = Money::new("9.00", "USD");
+    let cross = Envelope::seal(
+        &provider,
+        Offer {
+            job: dearer.id().unwrap(),
+            price: Money::new("0.042", "USD"),
+            expected_duration_ms: 12_000,
+            start_before: ts("2026-09-06T16:01:00.000Z"),
+            expires_at: ts("2026-09-06T16:00:30.000Z"),
+            capability_advert: None,
+            coordinator: false,
+        },
+    )
+    .unwrap();
+    assert!(book.submit(&cross, &job, &now).is_err());
+
+    // (d) manufacture reputation for a provider it favours
+    let mut ledger = ReputationLedger::new();
+    let flattering = Envelope::seal(
+        &buyer, // not the provider
+        Receipt {
+            job: job.id().unwrap(),
+            buyer: buyer.did().clone(),
+            provider: provider.did().clone(),
+            validator: None,
+            workload: WORKLOAD.into(),
+            offer: ContentHash::of(b"whatever"),
+            input_hash: None,
+            output_hash: Some(ContentHash::of(b"out")),
+            runtime_hash: None,
+            started_at: ts("2026-09-06T16:01:00.000Z"),
+            completed_at: ts("2026-09-06T16:01:01.000Z"),
+            price: Money::new("0.042", "USD"),
+            validation: ValidationOutcome {
+                policy: ValidationPolicy::default(),
+                status: ValidationStatus::Accepted,
+                detail: None,
+            },
+            settlement: SettlementRecord {
+                adapter: SettlementAdapter::coinpay(),
+                reference: None,
+                settled: true,
+            },
+        },
+    )
+    .unwrap();
+    assert!(ledger.record(&flattering).is_err());
+
+    // Nothing the courier touched got through.
+    assert!(directory.is_empty());
+    assert!(book.is_empty());
+    assert!(ledger.is_empty());
+}
+
+#[test]
+fn withholding_messages_degrades_the_market_without_corrupting_it() {
+    // The one thing an intermediary *can* do is show you less than exists.
+    // The buyer should end up with fewer choices, never a wrong one.
+    let now = ts("2026-09-06T16:00:05.000Z");
+    let buyer = SigningIdentity::from_seed(&[0x11; 32]);
+    let job = job_for(&buyer);
+
+    let mut directory = ProviderDirectory::new();
+    let mut book = OfferBook::for_job(&job).unwrap();
+
+    // Three providers advertise; a censoring indexer relays only one.
+    let providers: Vec<SigningIdentity> = (0..3)
+        .map(|i| SigningIdentity::from_seed(&[0x77 + i; 32]))
+        .collect();
+
+    let relayed = &providers[0];
+    let advert = Envelope::seal(relayed, advert()).unwrap();
+    directory.insert(&advert, &now).unwrap();
+
+    book.submit(
+        &Envelope::seal(
+            relayed,
+            Offer {
+                job: job.id().unwrap(),
+                price: Money::new("0.09", "USD"), // the worst price of the three
+                expected_duration_ms: 12_000,
+                start_before: ts("2026-09-06T16:01:00.000Z"),
+                expires_at: ts("2026-09-06T16:00:30.000Z"),
+                capability_advert: Some(advert.content_hash().unwrap()),
+                coordinator: false,
+            },
+        )
+        .unwrap(),
+        &job,
+        &now,
+    )
+    .unwrap();
+
+    let eligible = directory.eligible(&job, &now);
+    let dids: Vec<_> = eligible.iter().map(|r| r.provider.clone()).collect();
+    let selection = select(
+        SelectionPolicy::Cheapest,
+        &book.live_from(&dids, &now),
+        &job,
+        &ReputationLedger::new(),
+        &|_| TrustTier::Standard,
+    )
+    .unwrap();
+
+    // The buyer gets a worse deal than the full market would have given —
+    // and still a valid, verifiable, within-cap one. That is the correct
+    // failure mode for a non-authoritative index, and the reason a buyer
+    // who suspects it can go to the network directly.
+    assert_eq!(selection.ranked.len(), 1);
+    assert_eq!(selection.winner().record.offer.price.amount, "0.09");
+    assert!(
+        selection
+            .winner()
+            .record
+            .offer
+            .price
+            .is_within(&job.economics.max_price)
+            .unwrap()
+    );
+}


### PR DESCRIPTION
Phase 2's load-bearing half — backlog item 14, plus the parts of 11–13 and 18 that are logic rather than transport. New crate `c0mpute-market`.

This is the answer to *"if nobody is in the middle, who decides?"* Nothing on the network ranks offers; this code does, on the buyer's machine, under a policy the buyer named. A CLI, a delegated gateway and a private organization scheduler all link the same logic — and none is privileged over the others, because there is no network-wide matcher for them to be privileged *by*.

```text
adverts ──> ProviderDirectory ──┐
                                ├──> select(policy) ──> winning offer
offers  ──> OfferBook ──────────┤
receipts ─> ReputationLedger ───┘
```

| | |
|---|---|
| `ProviderDirectory` | newest signed advert per provider; expiry enforced on read as well as write, and a lower sequence never replaces a higher one |
| `OfferBook` | verified offers, one slot per provider, keeping the **best** rather than the latest so the book is independent of arrival order |
| `ReputationLedger` | provider statistics derived from signed receipts, rebuildable from a receipt log in any order |
| `select()` | cheapest / fastest / balanced / trusted / private |

## Two design points worth the reading time

**Proportional scoring, not min–max.** My first implementation normalized price across the candidate set, and the `balanced` test caught what that does: with two offers, a one-cent gap and a hundred-dollar gap both produce a 0.0-vs-1.0 split, so *any* price difference however trivial dominates every other dimension — and a provider that fails most of its jobs wins on being a cent cheaper. Scoring is now `best / value`: proportional and scale-invariant, so an offer 20% dearer scores 0.83. That test is the reason `balanced` behaves like its name rather than like `cheapest`.

**A new provider is not a bad provider.** Success rate is smoothed toward a neutral prior, so an unknown provider scores exactly 0.5. Raw rates make a provider's first job unwinnable at 0/0 — or make a fresh key with one success outrank a provider with a thousand jobs and two failures.

## Eligibility is not scoring

Kept strictly separate. **Eligibility** is correctness — right job, within cap, meets the deadline, hardware present — and failing it is disqualifying, not merely unattractive. **Scoring** is preference, and buyers are allowed to disagree.

- **VRAM does not sum across cards.** A model that does not fit on one 24 GiB card does not fit on two 12 GiB cards. Counts *do* sum, across cards that each individually meet the spec.
- **Price is exact decimal arithmetic.** Floats appear only in scoring, where a rounding error changes a preference rather than a gate.
- **Every rejection returns all failed requirements**, not the first — so "no providers found" can say which constraint actually binds instead of making the buyer relax them one at a time.

## Verification

62 tests. The one to read is `tests/gateway_none.rs`, which runs the full chain — advert → job → offer → selection → execution → receipt → countersignature — between two parties sharing **no memory, no database and no service**, with every fact crossing as JSON bytes through a `Wire` struct.

It also pins what a hostile intermediary can do. Four attacks a malicious indexer, relay or gateway would actually try — inflate a provider's capabilities, undercut a quote, re-point an offer at a dearer job, manufacture reputation — all rejected. Meanwhile withholding messages *degrades* the market without corrupting it: the buyer gets a worse price and still a valid, within-cap, verifiable one. That is the correct failure mode for a non-authoritative index, and the reason a buyer who suspects one can go to the network directly.

Also: `cargo clippy -- -D warnings` clean, `cargo fmt --check` clean, full workspace green (35 test binaries), protocol-docs check still passing.

## What this is not

**This is the protocol half of the `--gateway none` gate (§32 Tests A and B), not the whole gate.** There is no libp2p here, no DHT, no NAT traversal. The market logic runs; nothing yet carries adverts and offers between machines.

The docs say so rather than implying otherwise — `docs/protocol/README.md` now reads "Phase 1 complete, Phase 2 in progress… the **transport** is not", and the `/protocol` page's shipped/in-progress table moved scheduling and reputation to shipped while naming the transport as what remains.

**Not in this change:** the local daemon, DHT discovery, gossip announcements, offer collection over the wire, relay paths, and the CI testnet — backlog items 9, 10, 15, 16 and 21. The v1 unsigned gossip market in `c0mpute-net::topics` is untouched and still works, so nothing regresses while the v2 path is built alongside it.

## Docs

New `docs/protocol/scheduling.md` covering eligibility gates, the policy weight table, why `balanced` is the default, the determinism rules, and what an intermediary can and cannot do.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014YtSUWwT16LpvXoTyxeBGe
