### PR TITLE
Serve an OpenAccess descriptor

### DIFF
--- a/apps/web/public/.well-known/openaccess.json
+++ b/apps/web/public/.well-known/openaccess.json
@@ -1,0 +1,29 @@
+{
+  "openaccess": "0.1",
+  "name": "c0mpute",
+  "url": "https://c0mpute.com",
+  "operator": "https://logicsrc.com/.well-known/openprofile.md",
+  "redirect_uris": [
+    "https://c0mpute.com/api/v1/openaccess/callback"
+  ],
+  "jwks": {
+    "keys": [
+      {
+        "kty": "OKP",
+        "crv": "Ed25519",
+        "kid": "u0S7l8LxbDuV",
+        "x": "KmAo7ges7SKaOoTmEO_ab45zw2AYlm5QFEQYU3S0fOs",
+        "alg": "EdDSA",
+        "use": "sig"
+      }
+    ]
+  },
+  "scopes": {},
+  "honours": [
+    "profullstack.com/all-access"
+  ],
+  "webhooks": "https://c0mpute.com/api/v1/openaccess/events",
+  "hubs": [
+    "https://openaccess.logicsrc.com"
+  ]
+}


### PR DESCRIPTION
Adds `apps/web/public/.well-known/openaccess.json` so c0mpute.com is listed on [openaccess.logicsrc.com](https://openaccess.logicsrc.com/apps), can be linked with OAuth 2.1 + PKCE, and honours the shared `profullstack.com/all-access` entitlement. Static file only; no runtime change. The private key is vaulted in logicsrc teams `openaccess-app-keys--prod`.

Spec: https://logicsrc.com/openaccess

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SWRffW4ifQPUrGXJtgYWMd